### PR TITLE
feat: add max_age param for auth0

### DIFF
--- a/src/runtime/server/lib/oauth/auth0.ts
+++ b/src/runtime/server/lib/oauth/auth0.ts
@@ -39,6 +39,12 @@ export interface OAuthAuth0Config {
    * @default false
    */
   emailRequired?: boolean
+  /**
+   * Maximum Authentication Age. If the elapsed time is greater than this value, the OP must attempt to actively re-authenticate the end-user.
+   * @default 0
+   * @see https://auth0.com/docs/authenticate/login/max-age-reauthentication
+   */
+  maxAge?: number
 }
 
 export function auth0EventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthAuth0Config>) {
@@ -73,6 +79,7 @@ export function auth0EventHandler({ config, onSuccess, onError }: OAuthConfig<OA
           redirect_uri: redirectUrl,
           scope: config.scope.join(' '),
           audience: config.audience || '',
+          max_age: config.maxAge || 0,
         })
       )
     }


### PR DESCRIPTION
Forces reauthentication whenever user logs out, and shows Auth0 Universal Login Can be set when defining auth0EventHandler, same as `emailRequired`