### PR TITLE
fix(auth0): add audience to auth0 runtime config types

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -96,7 +96,8 @@ export default defineNuxtModule<ModuleOptions>({
     runtimeConfig.oauth.auth0 = defu(runtimeConfig.oauth.auth0, {
       clientId: '',
       clientSecret: '',
-      domain: ''
+      domain: '',
+      audience: ''
     })
     // Microsoft OAuth
     runtimeConfig.oauth.microsoft = defu(runtimeConfig.oauth.microsoft, {


### PR DESCRIPTION
This pull request aims to add `audience` to the auth0 runtime config types, since it should be possible to add it. Right now it says it's not assignable if it's the first time you are writing the config, which is a little bit misleading.

<img width="351" alt="image" src="https://github.com/Atinux/nuxt-auth-utils/assets/61996402/773dffd1-9fc3-4459-8262-505747d65406">
