### PR TITLE
feat: add auth0 connection parameter to config

### DIFF
--- a/src/runtime/server/lib/oauth/auth0.ts
+++ b/src/runtime/server/lib/oauth/auth0.ts
@@ -45,6 +45,13 @@ export interface OAuthAuth0Config {
    * @see https://auth0.com/docs/authenticate/login/max-age-reauthentication
    */
   maxAge?: number
+  /**
+   * Login connection. If no connection is specified, it will redirect to the standard Auth0 login page and show the Login Widget.
+   * @default '''
+   * @see https://auth0.com/docs/api/authentication#social
+   * @example 'github'
+   */
+  connection?: string
 }
 
 export function auth0EventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthAuth0Config>) {
@@ -80,6 +87,7 @@ export function auth0EventHandler({ config, onSuccess, onError }: OAuthConfig<OA
           scope: config.scope.join(' '),
           audience: config.audience || '',
           max_age: config.maxAge || 0,
+          connection: config.connection || ''
         })
       )
     }

--- a/src/runtime/server/lib/oauth/auth0.ts
+++ b/src/runtime/server/lib/oauth/auth0.ts
@@ -47,7 +47,7 @@ export interface OAuthAuth0Config {
   maxAge?: number
   /**
    * Login connection. If no connection is specified, it will redirect to the standard Auth0 login page and show the Login Widget.
-   * @default '''
+   * @default ''
    * @see https://auth0.com/docs/api/authentication#social
    * @example 'github'
    */


### PR DESCRIPTION
Adds the connection query parameter for Auth0 to the config, which causes the direct use of this connection instead of the default Auth0 login page.