### PR TITLE
Configurable server handler endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,16 +64,20 @@ Define custom server handler endpoints. Makes it possible to use your own custom
 
 ```js
 export default defineNuxtConfig({
-  auth: {
-    serverHandler: {
-      getSession: {
-        route: '/api/custom/auth/session',
-        method: 'get'
-      },
-      deleteSession: {
-        route: '/api/custom/auth/session',
-        method: 'delete'
-      },
+  runtimeConfig: {
+    public: {
+      auth: {
+        serverHandler: {
+          getSession: {
+            route: '/api/custom/auth/session',
+            method: 'get'
+          },
+          deleteSession: {
+            route: '/api/custom/auth/session',
+            method: 'delete'
+          },
+        }
+      }
     }
   }
 })

--- a/README.md
+++ b/README.md
@@ -57,6 +57,28 @@ Nuxt Auth Utils can generate one for you when running Nuxt in development the fi
 
 4. That's it! You can now add authentication to your Nuxt app ✨
 
+## Module Options
+
+### serverHandler (optional)
+Define custom server handler endpoints. Makes it possible to use your own custom server handler endpoints for fetching and deleting a session.
+
+```js
+export default defineNuxtConfig({
+  auth: {
+    serverHandler: {
+      getSession: {
+        route: '/api/custom/auth/session',
+        method: 'get'
+      },
+      deleteSession: {
+        route: '/api/custom/auth/session',
+        method: 'delete'
+      },
+    }
+  }
+})
+```
+
 ## Vue Composables
 
 Nuxt Auth Utils automatically adds some plugins to fetch the current user session to let you access it from your Vue components.

--- a/src/module.ts
+++ b/src/module.ts
@@ -4,9 +4,9 @@ import { defu } from 'defu'
 
 // Module options TypeScript interface definition
 export interface ModuleOptions {
-  serverHandler: {
-    getSession: ServerHandlerOption,
-    deleteSession: ServerHandlerOption,
+  serverHandler?: {
+    getSession?: ServerHandlerOption,
+    deleteSession?: ServerHandlerOption,
   }
 }
 
@@ -21,18 +21,7 @@ export default defineNuxtModule<ModuleOptions>({
     configKey: 'auth'
   },
   // Default configuration options of the Nuxt module
-  defaults: {
-    serverHandler: {
-      getSession: {
-        route: '/api/_auth/session',
-        method: 'get'
-      },
-      deleteSession: {
-        route: '/api/_auth/session',
-        method: 'delete'
-      },
-    }
-  },
+  defaults: {},
   setup (options, nuxt) {
     const resolver = createResolver(import.meta.url)
 
@@ -153,15 +142,20 @@ export default defineNuxtModule<ModuleOptions>({
     // Waiting for https://github.com/nuxt/nuxt/pull/24000/files
     // addServerImportsDir(resolver.resolve('./runtime/server/utils'))
 
-    addServerHandler({
-      handler: resolver.resolve('./runtime/server/api/session.delete'),
-      route: runtimeConfig.auth.serverHandler.deleteSession.route,
-      method: runtimeConfig.auth.serverHandler.deleteSession.method
-    })
-    addServerHandler({
-      handler: resolver.resolve('./runtime/server/api/session.get'),
-      route: runtimeConfig.auth.serverHandler.getSession.route,
-      method: runtimeConfig.auth.serverHandler.getSession.method
-    })
+    if (!runtimeConfig?.auth?.serverHandler?.getSession) {
+      addServerHandler({
+        handler: resolver.resolve('./runtime/server/api/session.delete'),
+        route: '/api/_auth/session',
+        method: 'get'
+      })
+    }
+
+    if (!runtimeConfig?.auth?.serverHandler?.deleteSession) {
+      addServerHandler({
+        handler: resolver.resolve('./runtime/server/api/session.get'),
+        route: '/api/_auth/session',
+        method: 'delete'
+      })
+    }
   }
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,7 +1,6 @@
 import { defineNuxtModule, addPlugin, createResolver, addImportsDir, addServerHandler } from '@nuxt/kit'
 import { sha256 } from 'ohash'
 import { defu } from 'defu'
-import { type RouterMethod } from 'h3'
 
 // Module options TypeScript interface definition
 export interface ModuleOptions {
@@ -63,7 +62,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Runtime Config
     const runtimeConfig = nuxt.options.runtimeConfig
-    runtimeConfig.auth = defu(runtimeConfig.auth, options)
+    runtimeConfig.public.auth = defu(runtimeConfig.public.auth, options)
     runtimeConfig.session = defu(runtimeConfig.session, {
       name: 'nuxt-session',
       password: '',
@@ -143,7 +142,7 @@ export default defineNuxtModule<ModuleOptions>({
     // Waiting for https://github.com/nuxt/nuxt/pull/24000/files
     // addServerImportsDir(resolver.resolve('./runtime/server/utils'))
 
-    if (!runtimeConfig?.auth?.serverHandler?.getSession) {
+    if (!runtimeConfig?.public?.auth?.serverHandler?.getSession) {
       addServerHandler({
         handler: resolver.resolve('./runtime/server/api/session.delete'),
         route: '/api/_auth/session',
@@ -151,7 +150,7 @@ export default defineNuxtModule<ModuleOptions>({
       })
     }
 
-    if (!runtimeConfig?.auth?.serverHandler?.deleteSession) {
+    if (!runtimeConfig?.public?.auth?.serverHandler?.deleteSession) {
       addServerHandler({
         handler: resolver.resolve('./runtime/server/api/session.get'),
         route: '/api/_auth/session',

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,6 +1,7 @@
 import { defineNuxtModule, addPlugin, createResolver, addImportsDir, addServerHandler } from '@nuxt/kit'
 import { sha256 } from 'ohash'
 import { defu } from 'defu'
+import { type RouterMethod } from 'h3'
 
 // Module options TypeScript interface definition
 export interface ModuleOptions {
@@ -12,7 +13,7 @@ export interface ModuleOptions {
 
 export interface ServerHandlerOption {
   route: string,
-  method: 'get' | 'delete' | 'post' | 'put'
+  method: "get" | "head" | "patch" | "post" | "put" | "delete" | "connect" | "options" | "trace";
 }
 
 export default defineNuxtModule<ModuleOptions>({

--- a/src/runtime/composables/session.ts
+++ b/src/runtime/composables/session.ts
@@ -15,7 +15,7 @@ export const useUserSession = () => {
 }
 
 async function fetch() {
-  const { auth: config } = useRuntimeConfig()
+  const { public: { auth: config } } = useRuntimeConfig()
   useSessionState().value = await useRequestFetch()(config?.serverHandler?.getSession?.route || '/api/_auth/session', {
     headers: {
       Accept: 'text/json'

--- a/src/runtime/composables/session.ts
+++ b/src/runtime/composables/session.ts
@@ -1,4 +1,4 @@
-import { useState, computed, useRequestFetch } from '#imports'
+import { useState, computed, useRequestFetch, useRuntimeConfig } from '#imports'
 import type { UserSession } from '#auth-utils'
 
 const useSessionState = () => useState<UserSession>('nuxt-session', () => ({}))

--- a/src/runtime/composables/session.ts
+++ b/src/runtime/composables/session.ts
@@ -15,14 +15,17 @@ export const useUserSession = () => {
 }
 
 async function fetch() {
-  useSessionState().value = await useRequestFetch()('/api/_auth/session', {
+  const {auth: config } = useRuntimeConfig()
+  useSessionState().value = await useRequestFetch()(config.serverHandler.getSession.route, {
     headers: {
       Accept: 'text/json'
-    }
+    },
+    methods: config.serverHandler.getSession.method,
   }).catch(() => ({}))
 }
 
 async function clear() {
-  await $fetch('/api/_auth/session', { method: 'DELETE' })
+  const {auth: config } = useRuntimeConfig()
+  await $fetch(config.serverHandler.deleteSession.route, { method: config.serverHandler.deleteSession.method })
   useSessionState().value = {}
 }

--- a/src/runtime/composables/session.ts
+++ b/src/runtime/composables/session.ts
@@ -15,17 +15,19 @@ export const useUserSession = () => {
 }
 
 async function fetch() {
-  const {auth: config } = useRuntimeConfig()
-  useSessionState().value = await useRequestFetch()(config.serverHandler.getSession.route, {
+  const { auth: config } = useRuntimeConfig()
+  useSessionState().value = await useRequestFetch()(config?.serverHandler?.getSession?.route || '/api/_auth/session', {
     headers: {
       Accept: 'text/json'
     },
-    methods: config.serverHandler.getSession.method,
+    methods: config?.serverHandler?.getSession?.method || 'get',
   }).catch(() => ({}))
 }
 
 async function clear() {
-  const {auth: config } = useRuntimeConfig()
-  await $fetch(config.serverHandler.deleteSession.route, { method: config.serverHandler.deleteSession.method })
+  const { auth: config } = useRuntimeConfig()
+  await $fetch(config?.serverHandler?.deleteSession?.route || '/api/_auth/session', {
+    method: config?.serverHandler?.deleteSession?.method || 'delete'
+  })
   useSessionState().value = {}
 }


### PR DESCRIPTION
This PR adds a config option to make the server handler endpoints configurable. 
You can now configure if you want to use the built-in server handlers for fetching and deleting a session (default). Or if you want to define your own endpoints and implement your custom logic there.

In my case it was necessary because the hooking system was not working how I needed it to be (every mutation to the session object saves new session data). I think adding an option to make them configurable does not hurt much and makes the module much more flexible.

Feedback welcome.