### PR TITLE
chore: server types

### DIFF
--- a/src/runtime/server/tsconfig.json
+++ b/src/runtime/server/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../../.nuxt/tsconfig.server.json"
+}


### PR DESCRIPTION
Only fixes the types for `useRuntimeConfig()`, but may be useful in the future. I usually have this as default for server folder and think it's a good practice.