### PR TITLE
fix(google): remove `redirectUrl` type

### DIFF
--- a/src/runtime/server/lib/oauth/google.ts
+++ b/src/runtime/server/lib/oauth/google.ts
@@ -44,12 +44,6 @@ export interface OAuthGoogleConfig {
    * @default 'https://oauth2.googleapis.com/token'
    */
   tokenURL?: string;
-
-  /**
-   * Redirect URL post authenticating via google
-   * @default '/auth/google'
-   */
-  redirectUrl: '/auth/google';
 }
 
 export function googleEventHandler({


### PR DESCRIPTION
The `redirectUrl` on the Google OAuth types should be removed:

- it's not used by any of the code, in fact it's the only provider that has it
- it's a required type so you have to provide it, and it has to be `'/auth/google'`

