### PR TITLE
fix: improved types for `useUserSession()`

### DIFF
--- a/src/runtime/composables/session.ts
+++ b/src/runtime/composables/session.ts
@@ -1,5 +1,5 @@
 import { useState, computed, useRequestFetch } from '#imports'
-import type { UserSession, UserSessionApi, ResolvedUserSession } from '#auth-utils'
+import type { UserSession, UserSessionApi } from '#auth-utils'
 
 const useSessionState = () => useState<UserSession>('nuxt-session', () => ({}))
 
@@ -7,7 +7,7 @@ export function useUserSession(): UserSessionApi {
   const sessionState = useSessionState()
   return {
     loggedIn: computed(() => Boolean(sessionState.value.user)),
-    user: computed(() => (sessionState.value.user || null) as ResolvedUserSession),
+    user: computed(() => (sessionState.value.user || null)),
     session: sessionState,
     fetch,
     clear

--- a/src/runtime/composables/session.ts
+++ b/src/runtime/composables/session.ts
@@ -1,13 +1,13 @@
 import { useState, computed, useRequestFetch } from '#imports'
-import type { UserSession } from '#auth-utils'
+import type { UserSession, UserSessionApi, ResolvedUserSession } from '#auth-utils'
 
 const useSessionState = () => useState<UserSession>('nuxt-session', () => ({}))
 
-export const useUserSession = () => {
+export function useUserSession(): UserSessionApi {
   const sessionState = useSessionState()
   return {
     loggedIn: computed(() => Boolean(sessionState.value.user)),
-    user: computed(() => sessionState.value.user || null),
+    user: computed(() => (sessionState.value.user || null) as ResolvedUserSession),
     session: sessionState,
     fetch,
     clear

--- a/src/runtime/types/index.ts
+++ b/src/runtime/types/index.ts
@@ -1,2 +1,2 @@
-export type { UserSession } from './session'
+export type { UserSession, UserSessionApi, ResolvedUserSession, UserSessionUserData } from './session'
 export type { OAuthConfig } from './oauth-config'

--- a/src/runtime/types/session.ts
+++ b/src/runtime/types/session.ts
@@ -2,10 +2,6 @@ import type { ComputedRef, Ref } from 'vue'
 
 export interface UserSessionUserData {}
 
-export interface ResolvedUserSession {
-  user: UserSessionUserData | null
-}
-
 export interface UserSession {
   user?: UserSessionUserData
 }

--- a/src/runtime/types/session.ts
+++ b/src/runtime/types/session.ts
@@ -13,7 +13,7 @@ export interface UserSession {
 // explicitly type
 export interface UserSessionApi {
   loggedIn: ComputedRef<boolean>
-  user: ComputedRef<ResolvedUserSession>
+  user: ComputedRef<UserSessionUserData | null>
   session: Ref<UserSession>,
   fetch: () => Promise<void>,
   clear: () => Promise<void>

--- a/src/runtime/types/session.ts
+++ b/src/runtime/types/session.ts
@@ -1,3 +1,20 @@
+import type { ComputedRef, Ref } from 'vue'
+
+export interface UserSessionUserData {}
+
+export interface ResolvedUserSession {
+  user: UserSessionUserData | null
+}
+
 export interface UserSession {
-  user?: {}
+  user?: UserSessionUserData
+}
+
+// explicitly type
+export interface UserSessionApi {
+  loggedIn: ComputedRef<boolean>
+  user: ComputedRef<ResolvedUserSession>
+  session: Ref<UserSession>,
+  fetch: () => Promise<void>,
+  clear: () => Promise<void>
 }


### PR DESCRIPTION
Issue: https://github.com/Atinux/nuxt-auth-utils/issues/38

By explicitly typing the `useUserSession()` we fix the types not being exported correctly. 

I tried to also fix the type augmentation with it, my PHPStorm was freaking out on types though so was hard to see if its fixed.

As far as I could test, if you augment `UserSessionUserData` the `user` should have the right data. Maybe worth confirming on your end.