### PR TITLE
fix: UserSession user type augmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,15 @@ You can define the type for your user session by creating a type declaration fil
 
 ```ts
 declare module '#auth-utils' {
+  interface User {
+    // Add your own fields
+  }
+
   interface UserSession {
-    // define the type here
+    // Add your own fields
   }
 }
+
 export {}
 ```
 

--- a/playground/auth.d.ts
+++ b/playground/auth.d.ts
@@ -1,17 +1,18 @@
 declare module '#auth-utils' {
+  interface User {
+    spotify?: any
+    github?: any
+    google?: any
+    twitch?: any
+    auth0?: any
+    microsoft?: any;
+    discord?: any
+    battledotnet?: any
+    keycloak?: any
+    linkedin?: any
+  }
+
   interface UserSession {
-    user: {
-      spotify?: any
-      github?: any
-      google?: any
-      twitch?: any
-      auth0?: any
-      microsoft?: any;
-      discord?: any
-      battledotnet?: any
-      keycloak?: any
-      linkedin?: any
-    }
     extended?: any
     loggedInAt: number
   }

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -3,7 +3,7 @@ import { useSession, createError } from 'h3'
 import { defu } from 'defu'
 import { createHooks } from 'hookable'
 import { useRuntimeConfig } from '#imports'
-import type { UserSession } from '#auth-utils'
+import type { User, UserSession } from '#auth-utils'
 
 export interface SessionHooks {
   /**
@@ -55,7 +55,7 @@ export async function requireUserSession(event: H3Event) {
     })
   }
 
-  return userSession
+  return userSession as UserSession & { user: User }
 }
 
 let sessionConfig: SessionConfig

--- a/src/runtime/types/index.ts
+++ b/src/runtime/types/index.ts
@@ -1,2 +1,2 @@
-export type { UserSession } from './session'
+export type { UserSession, User } from './session'
 export type { OAuthConfig } from './oauth-config'

--- a/src/runtime/types/session.ts
+++ b/src/runtime/types/session.ts
@@ -1,3 +1,6 @@
+export interface User {
+}
+
 export interface UserSession {
-  user?: {}
+  user?: User
 }


### PR DESCRIPTION
Closes #38
Closes #31

It seems like the `user` type inside the `UserSession` interface cannot be augmented directly so I created a separate `User` interface. This does work.

Fixing the possibly `undefined` after using `requireUserSession` is achieved by setting the type explicitly to be defined. (we can do this because we check it to be defined right before returning it)