### PR TITLE
feat: add authorizationParams in oauth config

### DIFF
--- a/playground/app.vue
+++ b/playground/app.vue
@@ -3,67 +3,67 @@ const { loggedIn, user, session, clear } = useUserSession()
 
 const providers = computed(() => [
   {
-    label: session.value.user?.github?.login || 'GitHub',
+    label: session.value.user?.github || 'GitHub',
     to: '/auth/github',
     disabled: Boolean(user.value?.github),
     icon: 'i-simple-icons-github',
   },
   {
-    label: session.value.user?.spotify?.display_name || 'Spotify',
+    label: session.value.user?.spotify || 'Spotify',
     to: '/auth/spotify',
     disabled: Boolean(user.value?.spotify),
     icon: 'i-simple-icons-spotify',
   },
   {
-    label: session.value.user?.google?.email || 'Google',
+    label: session.value.user?.google || 'Google',
     to: '/auth/google',
     disabled: Boolean(user.value?.google),
     icon: 'i-simple-icons-google',
   },
   {
-    label: session.value.user?.twitch?.login || 'Twitch',
+    label: session.value.user?.twitch || 'Twitch',
     to: '/auth/twitch',
     disabled: Boolean(user.value?.twitch),
     icon: 'i-simple-icons-twitch',
   },
   {
-    label: user.value?.auth0?.email || 'Auth0',
+    label: user.value?.auth0 || 'Auth0',
     to: '/auth/auth0',
     disabled: Boolean(user.value?.auth0),
     icon: 'i-simple-icons-auth0',
   },
   {
-    label: user.value?.discord?.username || 'Discord',
+    label: user.value?.discord || 'Discord',
     to: '/auth/discord',
     disabled: Boolean(user.value?.discord),
     icon: 'i-simple-icons-discord',
   },
   {
-    label: user.value?.battledotnet?.battletag || 'Battle.net',
+    label: user.value?.battledotnet || 'Battle.net',
     to: '/auth/battledotnet',
     disabled: Boolean(user.value?.battledotnet),
     icon: 'i-simple-icons-battledotnet',
   },
   {
-    label: user.value?.microsoft?.displayName || 'Microsoft',
+    label: user.value?.microsoft || 'Microsoft',
     to: '/auth/microsoft',
     disabled: Boolean(user.value?.microsoft),
     icon: 'i-simple-icons-microsoft',
   },
   {
-    label: user.value?.keycloak?.preferred_username || 'Keycloak',
+    label: user.value?.keycloak || 'Keycloak',
     to: '/auth/keycloak',
     disabled: Boolean(user.value?.keycloak),
     icon: 'i-simple-icons-redhat'
   },
   {
-    label: user.value?.linkedin?.email || 'LinkedIn',
+    label: user.value?.linkedin || 'LinkedIn',
     to: '/auth/linkedin',
     disabled: Boolean(user.value?.linkedin),
     icon: 'i-simple-icons-linkedin',
   },
   {
-    label: user.value?.cognito?.email || 'Cognito',
+    label: user.value?.cognito || 'Cognito',
     to: '/auth/cognito',
     disabled: Boolean(user.value?.cognito),
     icon: 'i-simple-icons-amazonaws',

--- a/playground/auth.d.ts
+++ b/playground/auth.d.ts
@@ -1,15 +1,16 @@
 declare module '#auth-utils' {
   interface User {
-    spotify?: any
-    github?: any
-    google?: any
-    twitch?: any
-    auth0?: any
-    microsoft?: any;
-    discord?: any
-    battledotnet?: any
-    keycloak?: any
-    linkedin?: any
+    spotify?: string
+    github?: string
+    google?: string
+    twitch?: string
+    auth0?: string
+    microsoft?: string
+    discord?: string
+    battledotnet?: string
+    keycloak?: string
+    linkedin?: string
+    cognito?: string
   }
 
   interface UserSession {

--- a/playground/server/routes/auth/auth0.get.ts
+++ b/playground/server/routes/auth/auth0.get.ts
@@ -5,7 +5,7 @@ export default oauth.auth0EventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {
-        auth0: user,
+        auth0: user.email
       },
       loggedInAt: Date.now()
     })

--- a/playground/server/routes/auth/battledotnet.get.ts
+++ b/playground/server/routes/auth/battledotnet.get.ts
@@ -2,7 +2,7 @@ export default oauth.battledotnetEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {
-        battledotnet: user,
+        battledotnet: user.battletag
       },
       loggedInAt: Date.now()
     })

--- a/playground/server/routes/auth/cognito.get.ts
+++ b/playground/server/routes/auth/cognito.get.ts
@@ -2,7 +2,7 @@ export default oauth.cognitoEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {
-        cognito: user,
+        cognito: user.email
       },
       loggedInAt: Date.now()
     })

--- a/playground/server/routes/auth/discord.get.ts
+++ b/playground/server/routes/auth/discord.get.ts
@@ -2,7 +2,7 @@ export default oauth.discordEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {
-        discord: user,
+        discord: user.username
       },
       loggedInAt: Date.now()
     })

--- a/playground/server/routes/auth/github.get.ts
+++ b/playground/server/routes/auth/github.get.ts
@@ -2,7 +2,7 @@ export default oauth.githubEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {
-        github: user,
+        github: user.login
       },
       loggedInAt: Date.now()
     })

--- a/playground/server/routes/auth/google.get.ts
+++ b/playground/server/routes/auth/google.get.ts
@@ -1,8 +1,13 @@
 export default oauth.googleEventHandler({
+  config: {
+    authorizationParams: {
+      access_type: 'offline'
+    }
+  },
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {
-        google: user,
+        google: user.email
       },
       loggedInAt: Date.now()
     })

--- a/playground/server/routes/auth/keycloak.get.ts
+++ b/playground/server/routes/auth/keycloak.get.ts
@@ -2,7 +2,7 @@ export default oauth.keycloakEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {
-        keycloak: user,
+        keycloak: user.preferred_username
       },
       loggedInAt: Date.now(),
     })

--- a/playground/server/routes/auth/linkedin.get.ts
+++ b/playground/server/routes/auth/linkedin.get.ts
@@ -5,7 +5,7 @@ export default oauth.linkedinEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {
-        linkedin: user,
+        linkedin: user.email
       },
       loggedInAt: Date.now()
     })

--- a/playground/server/routes/auth/microsoft.get.ts
+++ b/playground/server/routes/auth/microsoft.get.ts
@@ -2,12 +2,11 @@ export default oauth.microsoftEventHandler({
     async onSuccess(event, { user }) {
       await setUserSession(event, {
         user: {
-          microsoft: user,
+          microsoft: user.email
         },
         loggedInAt: Date.now()
       })
-  
+
       return sendRedirect(event, '/')
     }
   })
-  

--- a/playground/server/routes/auth/spotify.get.ts
+++ b/playground/server/routes/auth/spotify.get.ts
@@ -2,7 +2,7 @@ export default oauth.spotifyEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {
-        spotify: user,
+        spotify: user.id
       },
       loggedInAt: Date.now()
     })

--- a/playground/server/routes/auth/twitch.get.ts
+++ b/playground/server/routes/auth/twitch.get.ts
@@ -5,7 +5,7 @@ export default oauth.twitchEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {
-        twitch: user,
+        twitch: user.login
       },
       loggedInAt: Date.now()
     })

--- a/src/runtime/server/lib/oauth/auth0.ts
+++ b/src/runtime/server/lib/oauth/auth0.ts
@@ -52,12 +52,20 @@ export interface OAuthAuth0Config {
    * @example 'github'
    */
   connection?: string
+  /**
+   * Extra authorization parameters to provide to the authorization URL
+   * @see https://auth0.com/docs/api/authentication#social
+   * @example { display: 'popup' }
+   */
+  authorizationParams?: Record<string, string>
 }
 
 export function auth0EventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthAuth0Config>) {
   return eventHandler(async (event: H3Event) => {
     // @ts-ignore
-    config = defu(config, useRuntimeConfig(event).oauth?.auth0) as OAuthAuth0Config
+    config = defu(config, useRuntimeConfig(event).oauth?.auth0, {
+      authorizationParams: {}
+    }) as OAuthAuth0Config
     const { code } = getQuery(event)
 
     if (!config.clientId || !config.clientSecret || !config.domain) {
@@ -87,7 +95,8 @@ export function auth0EventHandler({ config, onSuccess, onError }: OAuthConfig<OA
           scope: config.scope.join(' '),
           audience: config.audience || '',
           max_age: config.maxAge || 0,
-          connection: config.connection || ''
+          connection: config.connection || '',
+          ...config.authorizationParams
         })
       )
     }

--- a/src/runtime/server/lib/oauth/battledotnet.ts
+++ b/src/runtime/server/lib/oauth/battledotnet.ts
@@ -42,6 +42,11 @@ export interface OAuthBattledotnetConfig {
    * @default 'https://oauth.battle.net/token'
    */
   tokenURL?: string
+  /**
+   * Extra authorization parameters to provide to the authorization URL
+   * @see https://develop.battle.net/documentation/guides/using-oauth/authorization-code-flow
+   */
+  authorizationParams?: Record<string, string>
 }
 
 export function battledotnetEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthBattledotnetConfig>) {
@@ -50,7 +55,8 @@ export function battledotnetEventHandler({ config, onSuccess, onError }: OAuthCo
     // @ts-ignore
     config = defu(config, useRuntimeConfig(event).oauth?.battledotnet, {
       authorizationURL: 'https://oauth.battle.net/authorize',
-      tokenURL: 'https://oauth.battle.net/token'
+      tokenURL: 'https://oauth.battle.net/token',
+      authorizationParams: {}
     }) as OAuthBattledotnetConfig
 
     const query = getQuery(event)
@@ -94,6 +100,7 @@ export function battledotnetEventHandler({ config, onSuccess, onError }: OAuthCo
           scope: config.scope.join(' '),
           state: randomUUID(), // Todo: handle PKCE flow
           response_type: 'code',
+          ...config.authorizationParams
         })
       )
     }

--- a/src/runtime/server/lib/oauth/cognito.ts
+++ b/src/runtime/server/lib/oauth/cognito.ts
@@ -32,12 +32,19 @@ export interface OAuthCognitoConfig {
    * @default []
    */
   scope?: string[]
+  /**
+   * Extra authorization parameters to provide to the authorization URL
+   * @see https://docs.aws.amazon.com/cognito/latest/developerguide/authorization-endpoint.html
+   */
+  authorizationParams?: Record<string, string>
 }
 
 export function cognitoEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthCognitoConfig>) {
   return eventHandler(async (event: H3Event) => {
     // @ts-ignore
-    config = defu(config, useRuntimeConfig(event).oauth?.cognito) as OAuthCognitoConfig
+    config = defu(config, useRuntimeConfig(event).oauth?.cognito, {
+      authorizationParams: {}
+    }) as OAuthCognitoConfig
     const { code } = getQuery(event)
 
     if (!config.clientId || !config.clientSecret || !config.userPoolId || !config.region) {
@@ -63,6 +70,7 @@ export function cognitoEventHandler({ config, onSuccess, onError }: OAuthConfig<
           redirect_uri: redirectUrl,
           response_type: 'code',
           scope: config.scope.join(' '),
+          ...config.authorizationParams
         })
       )
     }

--- a/src/runtime/server/lib/oauth/discord.ts
+++ b/src/runtime/server/lib/oauth/discord.ts
@@ -45,6 +45,13 @@ export interface OAuthDiscordConfig {
    * @default 'https://discord.com/api/oauth2/token'
    */
   tokenURL?: string
+
+  /**
+   * Extra authorization parameters to provide to the authorization URL
+   * @see 'https://discord.com/developers/docs/topics/oauth2#authorization-code-grant'
+   * @example { allow_signup: 'true' }
+   */
+  authorizationParams?: Record<string, string>
 }
 
 export function discordEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthDiscordConfig>) {
@@ -53,7 +60,8 @@ export function discordEventHandler({ config, onSuccess, onError }: OAuthConfig<
     config = defu(config, useRuntimeConfig(event).oauth?.discord, {
       authorizationURL: 'https://discord.com/oauth2/authorize',
       tokenURL: 'https://discord.com/api/oauth2/token',
-      profileRequired: true
+      profileRequired: true,
+      authorizationParams: {}
     }) as OAuthDiscordConfig
     const { code } = getQuery(event)
 
@@ -83,7 +91,8 @@ export function discordEventHandler({ config, onSuccess, onError }: OAuthConfig<
           response_type: 'code',
           client_id: config.clientId,
           redirect_uri: redirectUrl,
-          scope: config.scope.join(' ')
+          scope: config.scope.join(' '),
+          ...config.authorizationParams
         })
       )
     }

--- a/src/runtime/server/lib/oauth/github.ts
+++ b/src/runtime/server/lib/oauth/github.ts
@@ -41,6 +41,13 @@ export interface OAuthGitHubConfig {
    * @default 'https://github.com/login/oauth/access_token'
    */
   tokenURL?: string
+
+  /**
+   * Extra authorization parameters to provide to the authorization URL
+   * @see https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#1-request-a-users-github-identity
+   * @example { allow_signup: 'true' }
+   */
+  authorizationParams?: Record<string, string>
 }
 
 export function githubEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthGitHubConfig>) {
@@ -48,7 +55,8 @@ export function githubEventHandler({ config, onSuccess, onError }: OAuthConfig<O
     // @ts-ignore
     config = defu(config, useRuntimeConfig(event).oauth?.github, {
       authorizationURL: 'https://github.com/login/oauth/authorize',
-      tokenURL: 'https://github.com/login/oauth/access_token'
+      tokenURL: 'https://github.com/login/oauth/access_token',
+      authorizationParams: {}
     }) as OAuthGitHubConfig
     const { code } = getQuery(event)
 
@@ -73,7 +81,8 @@ export function githubEventHandler({ config, onSuccess, onError }: OAuthConfig<O
         withQuery(config.authorizationURL as string, {
           client_id: config.clientId,
           redirect_uri: redirectUrl,
-          scope: config.scope.join(' ')
+          scope: config.scope.join(' '),
+          ...config.authorizationParams
         })
       )
     }

--- a/src/runtime/server/lib/oauth/google.ts
+++ b/src/runtime/server/lib/oauth/google.ts
@@ -44,6 +44,13 @@ export interface OAuthGoogleConfig {
    * @default 'https://oauth2.googleapis.com/token'
    */
   tokenURL?: string;
+
+  /**
+   * Extra authorization parameters to provide to the authorization URL
+   * @see https://developers.google.com/identity/protocols/oauth2/web-server#httprest_3
+   * @example { access_type: 'offline' }
+   */
+  authorizationParams?: Record<string, string>;
 }
 
 export function googleEventHandler({
@@ -56,6 +63,7 @@ export function googleEventHandler({
     config = defu(config, useRuntimeConfig(event).oauth?.google, {
       authorizationURL: 'https://accounts.google.com/o/oauth2/v2/auth',
       tokenURL: 'https://oauth2.googleapis.com/token',
+      authorizationParams: {}
     }) as OAuthGoogleConfig
     const { code } = getQuery(event)
 
@@ -79,6 +87,7 @@ export function googleEventHandler({
           client_id: config.clientId,
           redirect_uri: redirectUrl,
           scope: config.scope.join(' '),
+          ...config.authorizationParams
         })
       )
     }

--- a/src/runtime/server/lib/oauth/keycloak.ts
+++ b/src/runtime/server/lib/oauth/keycloak.ts
@@ -41,6 +41,10 @@ export interface OAuthKeycloakConfig {
    * @example ['openid']
    */
   scope?: string[]
+  /**
+   * Extra authorization parameters to provide to the authorization URL
+   */
+  authorizationParams?: Record<string, string>
 }
 
 export function keycloakEventHandler({
@@ -49,11 +53,10 @@ export function keycloakEventHandler({
   onError,
 }: OAuthConfig<OAuthKeycloakConfig>) {
   return eventHandler(async (event: H3Event) => {
-    config = defu(
-      config,
-      // @ts-ignore
-      useRuntimeConfig(event).oauth?.keycloak
-    ) as OAuthKeycloakConfig
+    // @ts-ignore
+    config = defu(config, useRuntimeConfig(event).oauth?.keycloak, {
+      authorizationParams: {},
+    }) as OAuthKeycloakConfig
 
     const query = getQuery(event)
     const { code } = query
@@ -100,6 +103,7 @@ export function keycloakEventHandler({
           redirect_uri: redirectUrl,
           scope: config.scope.join(' '),
           response_type: 'code',
+          ...config.authorizationParams,
         })
       )
     }

--- a/src/runtime/server/lib/oauth/linkedin.ts
+++ b/src/runtime/server/lib/oauth/linkedin.ts
@@ -38,6 +38,11 @@ export interface OAuthLinkedInConfig {
    * @default 'https://www.linkedin.com/oauth/v2/accessToken'
    */
   tokenURL?: string
+  /**
+   * Extra authorization parameters to provide to the authorization URL
+   * @see https://docs.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow?context=linkedin/context
+   */
+  authorizationParams?: Record<string, string>
 }
 
 interface OAuthConfig {
@@ -52,6 +57,7 @@ export function linkedinEventHandler({ config, onSuccess, onError }: OAuthConfig
     config = defu(config, useRuntimeConfig(event).oauth?.linkedin, {
       authorizationURL: 'https://www.linkedin.com/oauth/v2/authorization',
       tokenURL: 'https://www.linkedin.com/oauth/v2/accessToken',
+      authorizationParams: {}
     }) as OAuthLinkedInConfig
     const { code } = getQuery(event)
 
@@ -80,7 +86,8 @@ export function linkedinEventHandler({ config, onSuccess, onError }: OAuthConfig
           response_type: 'code',
           client_id: config.clientId,
           redirect_uri: redirectUrl,
-          scope: config.scope.join(' ')
+          scope: config.scope.join(' '),
+          ...config.authorizationParams
         })
       )
     }

--- a/src/runtime/server/lib/oauth/microsoft.ts
+++ b/src/runtime/server/lib/oauth/microsoft.ts
@@ -29,22 +29,27 @@ export interface OAuthMicrosoftConfig {
   scope?: string[]
   /**
    * Microsoft OAuth Authorization URL
-   * @default https://login.microsoftonline.com/${tenant}/oauth2/v2.0/authorize
+   * @default 'https://login.microsoftonline.com/${tenant}/oauth2/v2.0/authorize'
    * @see https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow
    */
   authorizationURL?: string
   /**
    * Microsoft OAuth Token URL
-   * @default https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token
+   * @default 'https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token'
    * @see https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow
    */
   tokenURL?: string
   /**
    * Microsoft OAuth User URL
-   * @default https://graph.microsoft.com/v1.0/me
+   * @default 'https://graph.microsoft.com/v1.0/me'
    * @see https://docs.microsoft.com/en-us/graph/api/user-get?view=graph-rest-1.0&tabs=http
    */
   userURL?: string
+  /**
+   * Extra authorization parameters to provide to the authorization URL
+   * @see https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow
+   */
+  authorizationParams?: Record<string, string>
 }
 
 interface OAuthConfig {
@@ -56,7 +61,9 @@ interface OAuthConfig {
 export function microsoftEventHandler({ config, onSuccess, onError }: OAuthConfig) {
   return eventHandler(async (event: H3Event) => {
     // @ts-ignore
-    config = defu(config, useRuntimeConfig(event).oauth?.microsoft) as OAuthMicrosoftConfig
+    config = defu(config, useRuntimeConfig(event).oauth?.microsoft, {
+      authorizationParams: {}
+    }) as OAuthMicrosoftConfig
     const { code } = getQuery(event)
 
     if (!config.clientId || !config.clientSecret || !config.tenant) {
@@ -83,6 +90,7 @@ export function microsoftEventHandler({ config, onSuccess, onError }: OAuthConfi
           response_type: 'code',
           redirect_uri: redirectUrl,
           scope: scope.join(' '),
+          ...config.authorizationParams
         })
       )
     }

--- a/src/runtime/server/lib/oauth/spotify.ts
+++ b/src/runtime/server/lib/oauth/spotify.ts
@@ -41,6 +41,13 @@ export interface OAuthSpotifyConfig {
    * @default 'https://accounts.spotify.com/api/token'
    */
   tokenURL?: string
+
+  /**
+   * Extra authorization parameters to provide to the authorization URL
+   * @see 'https://developer.spotify.com/documentation/web-api/tutorials/code-flow'
+   * @example { show_dialog: 'true' }
+   */
+  authorizationParams?: Record<string, string>
 }
 
 export function spotifyEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthSpotifyConfig>) {
@@ -48,7 +55,8 @@ export function spotifyEventHandler({ config, onSuccess, onError }: OAuthConfig<
     // @ts-ignore
     config = defu(config, useRuntimeConfig(event).oauth?.spotify, {
       authorizationURL: 'https://accounts.spotify.com/authorize',
-      tokenURL: 'https://accounts.spotify.com/api/token'
+      tokenURL: 'https://accounts.spotify.com/api/token',
+      authorizationParams: {}
     }) as OAuthSpotifyConfig
     const { code } = getQuery(event)
 
@@ -74,7 +82,8 @@ export function spotifyEventHandler({ config, onSuccess, onError }: OAuthConfig<
           response_type: 'code',
           client_id: config.clientId,
           redirect_uri: redirectUrl,
-          scope: config.scope.join(' ')
+          scope: config.scope.join(' '),
+          ...config.authorizationParams
         })
       )
     }

--- a/src/runtime/server/lib/oauth/twitch.ts
+++ b/src/runtime/server/lib/oauth/twitch.ts
@@ -44,6 +44,13 @@ export interface OAuthTwitchConfig {
    * @default 'https://id.twitch.tv/oauth2/token'
    */
   tokenURL?: string
+
+  /**
+   * Extra authorization parameters to provide to the authorization URL
+   * @see https://dev.twitch.tv/docs/authentication/getting-tokens-oauth/#authorization-code-grant-flow
+   * @example { force_verify: 'true' }
+   */
+  authorizationParams?: Record<string, string>
 }
 
 export function twitchEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthTwitchConfig>) {
@@ -51,7 +58,8 @@ export function twitchEventHandler({ config, onSuccess, onError }: OAuthConfig<O
     // @ts-ignore
     config = defu(config, useRuntimeConfig(event).oauth?.twitch, {
       authorizationURL: 'https://id.twitch.tv/oauth2/authorize',
-      tokenURL: 'https://id.twitch.tv/oauth2/token'
+      tokenURL: 'https://id.twitch.tv/oauth2/token',
+      authorizationParams: {}
     }) as OAuthTwitchConfig
     const { code } = getQuery(event)
 
@@ -77,7 +85,8 @@ export function twitchEventHandler({ config, onSuccess, onError }: OAuthConfig<O
           response_type: 'code',
           client_id: config.clientId,
           redirect_uri: redirectUrl,
-          scope: config.scope.join(' ')
+          scope: config.scope.join(' '),
+          ...config.authorizationParams
         })
       )
     }

--- a/src/runtime/types/oauth-config.ts
+++ b/src/runtime/types/oauth-config.ts
@@ -1,7 +1,6 @@
 import type { H3Event, H3Error } from 'h3'
-import type { UserSession } from '#auth-utils'
 
-export interface OAuthConfig<TConfig, TUser = UserSession, TTokens = any> {
+export interface OAuthConfig<TConfig, TUser = any, TTokens = any> {
   config?: TConfig;
   onSuccess: (
     event: H3Event,


### PR DESCRIPTION
Resolves #22
Resolves #43 by overwriting `redirect_uri` in `authorizationParams`

This pull request introduce `authorizationParams` option in each OAuth provider, example:

```ts
export default oauth.googleEventHandler({
  config: {
    authorizationParams: {
      access_type: 'offline'
    }
  },
  async onSuccess(event, { user }) {
    // ...
  }
})
```

The `authorizationParams` can overwrite the generated params we provide and this can be useful in case such as #43 

```ts
export default oauth.microsoftEventHandler({
  config: {
    authorizationParams: {
      redirect_uri: 'https://my-custom-redirect-uri'
    }
  },
    async onSuccess(event, { user }) {
      // ...
    }
})
```