### PR TITLE
feat: private session data

### DIFF
--- a/src/runtime/composables/session.ts
+++ b/src/runtime/composables/session.ts
@@ -1,7 +1,7 @@
 import { useState, computed, useRequestFetch } from '#imports'
-import type { UserSession, UserSessionComposable } from '#auth-utils'
+import type { PublicSessionData, UserSessionComposable } from '#auth-utils'
 
-const useSessionState = () => useState<UserSession>('nuxt-session', () => ({}))
+const useSessionState = () => useState<PublicSessionData>('nuxt-session', () => ({}))
 
 export function useUserSession(): UserSessionComposable  {
   const sessionState = useSessionState()

--- a/src/runtime/server/api/session.get.ts
+++ b/src/runtime/server/api/session.get.ts
@@ -6,5 +6,5 @@ export default eventHandler(async (event) => {
 
   await sessionHooks.callHookParallel('fetch', session, event)
 
-  return session
+  return session.public
 })

--- a/src/runtime/types/index.ts
+++ b/src/runtime/types/index.ts
@@ -1,2 +1,2 @@
-export type { User, UserSession, UserSessionComposable } from './session'
+export type { PrivateSessionData, PublicSessionData, User, UserSessionComposable } from './session'
 export type { OAuthConfig } from './oauth-config'

--- a/src/runtime/types/session.ts
+++ b/src/runtime/types/session.ts
@@ -3,14 +3,27 @@ import type { ComputedRef, Ref } from 'vue'
 export interface User {
 }
 
-export interface UserSession {
+export interface PublicSessionData {
   user?: User
+}
+
+export interface PrivateSessionData {
+}
+
+export interface UserSession extends PrivateSessionData {
+  public: PublicSessionData
+}
+
+export interface ActiveUserSession extends UserSession {
+  public: { 
+    user: User
+  }
 }
 
 export interface UserSessionComposable {
   loggedIn: ComputedRef<boolean>
   user: ComputedRef<User | null>
-  session: Ref<UserSession>,
+  session: Ref<PublicSessionData>,
   fetch: () => Promise<void>,
   clear: () => Promise<void>
 }


### PR DESCRIPTION
I have added a `public` object to the `SessionData` which still contains the `User` type like before.
The `setUserSession` and `replaceUserSession` have the parameters as described in #47 

The `SessionData` type is no longer exposed in favor of `PublicSessionData` and `PrivateSessionData`.
(only used internally from now on)

I'm not really sure about this solution yet.
What I'm thinking is to let go of the `user` property as a session check and instead just use `public` like `user` is used right now. There won't be a built in computed `user` but this can easily be added by wrapping the `useUserSession`:
```ts
export default function userStore() {
  const { session, clear, fetch, loggedIn } = useUserSession();

  const user = computed(() => session.value.user || null);

  return {
    user,
    session,
    clear,
    fetch,
    loggedIn
  };
}
```
This way you don't have to use `user` and can add anything you want (as long as there is _something_)
Problem is.. `useUserSession` is already taken as composable name