### PR TITLE
fix: narrowed session type passed to `fetch` session hook

### DIFF
--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -4,7 +4,7 @@ import { defu } from 'defu'
 import { createHooks } from 'hookable'
 import { useRuntimeConfig } from '#imports'
 import type { UserSession } from '#auth-utils'
-import { ActiveUserSession } from '../../types/session'
+import type { ActiveUserSession } from '../../types/session'
 
 export interface SessionHooks {
   /**

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -3,7 +3,8 @@ import { useSession, createError } from 'h3'
 import { defu } from 'defu'
 import { createHooks } from 'hookable'
 import { useRuntimeConfig } from '#imports'
-import type { User, UserSession } from '#auth-utils'
+import type { UserSession } from '#auth-utils'
+import { ActiveUserSession } from '../../types/session'
 
 export interface SessionHooks {
   /**
@@ -11,7 +12,7 @@ export interface SessionHooks {
    * - Add extra properties to the session
    * - Throw an error if the session could not be verified (with a database for example)
    */
-  'fetch': (session: UserSession, event: H3Event) => void | Promise<void>
+  'fetch': (session: ActiveUserSession, event: H3Event) => void | Promise<void>
   /**
    * Called before clearing the session
    */
@@ -59,7 +60,7 @@ export async function clearUserSession (event: H3Event) {
   return true
 }
 
-export async function requireUserSession(event: H3Event): Promise<UserSession & { user: User }> {
+export async function requireUserSession(event: H3Event): Promise<ActiveUserSession> {
   const userSession = await getUserSession(event)
 
   if (!userSession.user) {
@@ -69,7 +70,7 @@ export async function requireUserSession(event: H3Event): Promise<UserSession & 
     })
   }
 
-  return userSession as UserSession & { user: User }
+  return userSession as ActiveUserSession
 }
 
 let sessionConfig: SessionConfig

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -3,8 +3,7 @@ import { useSession, createError } from 'h3'
 import { defu } from 'defu'
 import { createHooks } from 'hookable'
 import { useRuntimeConfig } from '#imports'
-import type { UserSession } from '#auth-utils'
-import type { ActiveUserSession } from '../../types/session'
+import type { UserSession, UserSessionRequired } from '#auth-utils'
 
 export interface SessionHooks {
   /**
@@ -12,7 +11,7 @@ export interface SessionHooks {
    * - Add extra properties to the session
    * - Throw an error if the session could not be verified (with a database for example)
    */
-  'fetch': (session: ActiveUserSession, event: H3Event) => void | Promise<void>
+  'fetch': (session: UserSessionRequired, event: H3Event) => void | Promise<void>
   /**
    * Called before clearing the session
    */
@@ -60,7 +59,7 @@ export async function clearUserSession (event: H3Event) {
   return true
 }
 
-export async function requireUserSession(event: H3Event): Promise<ActiveUserSession> {
+export async function requireUserSession(event: H3Event): Promise<UserSessionRequired> {
   const userSession = await getUserSession(event)
 
   if (!userSession.user) {
@@ -70,7 +69,7 @@ export async function requireUserSession(event: H3Event): Promise<ActiveUserSess
     })
   }
 
-  return userSession as ActiveUserSession
+  return userSession as UserSessionRequired
 }
 
 let sessionConfig: SessionConfig

--- a/src/runtime/types/index.ts
+++ b/src/runtime/types/index.ts
@@ -1,2 +1,2 @@
-export type { User, UserSession, UserSessionComposable } from './session'
+export type { User, UserSession, UserSessionRequired, UserSessionComposable } from './session'
 export type { OAuthConfig } from './oauth-config'

--- a/src/runtime/types/session.ts
+++ b/src/runtime/types/session.ts
@@ -7,6 +7,10 @@ export interface UserSession {
   user?: User
 }
 
+export interface ActiveUserSession extends UserSession {
+  user: User
+}
+
 export interface UserSessionComposable {
   loggedIn: ComputedRef<boolean>
   user: ComputedRef<User | null>

--- a/src/runtime/types/session.ts
+++ b/src/runtime/types/session.ts
@@ -7,7 +7,7 @@ export interface UserSession {
   user?: User
 }
 
-export interface ActiveUserSession extends UserSession {
+export interface UserSessionRequired extends UserSession {
   user: User
 }
 


### PR DESCRIPTION
The return value of `requireUserSession` is guaranteed to have the `user` component defined.
Previously, the return type was changed to reflect that fact but the session type passed to the `fetch` hook was not.
(It was not immediately clear to me, but the result of `requireUserSession` is passed into the `fetch` hook)
This fixes that and should avoid users to do an unnecessary check when hooking into `fetch`

Previously:
```ts
export default defineNitroPlugin(() => {
  sessionHooks.hook('fetch', (session, event) => {
    // session.user is possibly undefined, so we add a guard
    if (!session.user)
      // Do something

    // Do what you actually wanted to do with 'session.user'
  });
});
```

With this PR:
```ts
export default defineNitroPlugin(() => {
  sessionHooks.hook('fetch', (session, event) => {
    // session.user is defined so you can immediately do things without the need for a check
  });
});
```

Also, `ActiveUserSession` is not exposed because the type is completely defined by `UserSession` and `User`.
