### PR TITLE
Feature: Add redirectUrl to OAuthMicrosoftConfig for HTTP vs HTTPS Handling

### DIFF
--- a/src/runtime/server/lib/oauth/microsoft.ts
+++ b/src/runtime/server/lib/oauth/microsoft.ts
@@ -50,6 +50,12 @@ export interface OAuthMicrosoftConfig {
    * @see https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow
    */
   authorizationParams?: Record<string, string>
+  /**
+   * Redirect URL to prevent in prod prevent redirect_uri mismatch http to https
+   * @default process.env.NUXT_OAUTH_MICROSOFT_REDIRECT_URL
+   * @see https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow
+   */
+  redirectUrl?: string
 }
 
 interface OAuthConfig {
@@ -78,7 +84,7 @@ export function microsoftEventHandler({ config, onSuccess, onError }: OAuthConfi
     const authorizationURL = config.authorizationURL || `https://login.microsoftonline.com/${config.tenant}/oauth2/v2.0/authorize`
     const tokenURL = config.tokenURL || `https://login.microsoftonline.com/${config.tenant}/oauth2/v2.0/token`
 
-    const redirectUrl = getRequestURL(event).href
+    const redirectUrl =  config.redirectUrl || getRequestURL(event).href
     if (!code) {
 
       const scope = config.scope && config.scope.length > 0 ? config.scope : ['User.Read']


### PR DESCRIPTION
**Problem Statement**
In the current implementation of the Microsoft OAuth configuration within our Nuxt 3 library, there's no explicit way to define the protocol (HTTP or HTTPS) in the redirect URL. This limitation can lead to mismatches between the protocol used by the application and the callback URL expected by Microsoft's OAuth service, especially in environments where both HTTP and HTTPS are used or during the development stages where HTTP is more common.

**Proposed Solution**
This PR introduces a new configuration option, redirectUrl, to the OAuthMicrosoftConfig. The redirectUrl allows developers to explicitly set the full URL, including the protocol, that will be used as the callback URL in the OAuth flow. This enhancement ensures greater flexibility and control, allowing for seamless operation across different environments and addressing issues related to protocol mismatches.

**Implementation Details**
The redirectUrl option is optional. If not provided, the library will continue to operate as it currently does, automatically determining the redirect URL based on the request.
When redirectUrl is specified, it will be used as the callback URL in the OAuth request to Microsoft, overriding any automatically determined value.
This feature does not break any existing functionality or configurations. It simply provides an additional layer of configurability for those who need it

**Use Case**
A typical use case for this feature would be in a development environment where the application is served over HTTP but needs to be tested against a production OAuth configuration that expects HTTPS in the callback URL. By explicitly setting the redirectUrl to an HTTPS URL, developers can test the OAuth flow without having to change their local environment setup or the application's code to force HTTPS.

**Conclusion**
The addition of the redirectUrl option to OAuthMicrosoftConfig offers developers a straightforward and effective way to manage protocol discrepancies in OAuth callback URLs. This feature enhances the library's flexibility and usability, particularly in mixed protocol environments or during the development process.