### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,14 +26,7 @@ This module only works with SSR (server-side rendering) enabled as it uses serve
 1. Add `nuxt-auth-utils` dependency to your project
 
 ```bash
-# Using pnpm
-pnpm add -D nuxt-auth-utils
-
-# Using yarn
-yarn add --dev nuxt-auth-utils
-
-# Using npm
-npm install --save-dev nuxt-auth-utils
+npx nuxi@latest module add auth-utils
 ```
 
 2. Add `nuxt-auth-utils` to the `modules` section of `nuxt.config.ts`

--- a/README.md
+++ b/README.md
@@ -23,23 +23,13 @@ This module only works with SSR (server-side rendering) enabled as it uses serve
 
 ## Quick Setup
 
-1. Add `nuxt-auth-utils` dependency to your project
+1. Add `nuxt-auth-utils` in your Nuxt project
 
 ```bash
 npx nuxi@latest module add auth-utils
 ```
 
-2. Add `nuxt-auth-utils` to the `modules` section of `nuxt.config.ts`
-
-```js
-export default defineNuxtConfig({
-  modules: [
-    'nuxt-auth-utils'
-  ]
-})
-```
-
-3. Add a `NUXT_SESSION_PASSWORD` env variable with at least 32 characters in the `.env`.
+2. Add a `NUXT_SESSION_PASSWORD` env variable with at least 32 characters in the `.env`.
 
 ```bash
 # .env
@@ -49,7 +39,6 @@ NUXT_SESSION_PASSWORD=password-with-at-least-32-characters
 Nuxt Auth Utils generates one for you when running Nuxt in development the first time if no `NUXT_SESSION_PASSWORD` is set.
 
 3. That's it! You can now add authentication to your Nuxt app ✨
-
 
 ## Vue Composables
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
