### PR TITLE
fix: avoid duplicate trigger of session fetch hook due to request retry

### DIFF
--- a/src/runtime/composables/session.ts
+++ b/src/runtime/composables/session.ts
@@ -19,6 +19,7 @@ async function fetch() {
     headers: {
       Accept: 'text/json',
     },
+    retry: false
   }).catch(() => ({}))
 }
 


### PR DESCRIPTION
The nitro session fetch hook is likely to be used for implementing the necessary checks to ensure token validity, this might require making additional network requests to the pertinent authentication server.

The current implementation results in the aforementioned checks being made twice whenever the **session cookie is present**, and the **earlier checks have failed** (_returned `throw createError()` within session fetch hook_), hence resulting in unnecessary overhead.