### PR TITLE
feat: add fields support to facebook provider

### DIFF
--- a/playground/server/plugins/session.ts
+++ b/playground/server/plugins/session.ts
@@ -1,4 +1,4 @@
-export default defineNitroPlugin(() => {
+export default defineNitroPlugin((nitroApp) => {
   sessionHooks.hook('fetch', async (session) => {
     // Extend User Session
     // Or throw createError({ ... }) if session is invalid
@@ -10,5 +10,22 @@ export default defineNitroPlugin(() => {
   sessionHooks.hook('clear', async (_session) => {
     // Log that user logged out
     console.log('User logged out')
+  })
+
+  // In facebook login, the url is redirected to /#_=_ which is not a valid route
+  // so we remove it from the url, we are loading this long before the app is loaded
+  // by using render:html hook
+  // this is a hack, but it works
+  // https://stackoverflow.com/questions/7131909/facebook-callback-appends-to-return-url
+  nitroApp.hooks.hook('render:html', (html) => {
+    html.head.unshift(`
+      <script>
+        if (window.location.hash === "#_=_"){
+          history.replaceState
+              ? history.replaceState(null, null, window.location.href.split("#")[0])
+              : window.location.hash = "";
+        }
+      </script>
+    `)
   })
 })

--- a/playground/server/plugins/session.ts
+++ b/playground/server/plugins/session.ts
@@ -1,4 +1,4 @@
-export default defineNitroPlugin((nitroApp) => {
+export default defineNitroPlugin(() => {
   sessionHooks.hook('fetch', async (session) => {
     // Extend User Session
     // Or throw createError({ ... }) if session is invalid
@@ -10,22 +10,5 @@ export default defineNitroPlugin((nitroApp) => {
   sessionHooks.hook('clear', async (_session) => {
     // Log that user logged out
     console.log('User logged out')
-  })
-
-  // In facebook login, the url is redirected to /#_=_ which is not a valid route
-  // so we remove it from the url, we are loading this long before the app is loaded
-  // by using render:html hook
-  // this is a hack, but it works
-  // https://stackoverflow.com/questions/7131909/facebook-callback-appends-to-return-url
-  nitroApp.hooks.hook('render:html', (html) => {
-    html.head.unshift(`
-      <script>
-        if (window.location.hash === "#_=_"){
-          history.replaceState
-              ? history.replaceState(null, null, window.location.href.split("#")[0])
-              : window.location.hash = "";
-        }
-      </script>
-    `)
   })
 })

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,5 +1,5 @@
 import { writeFile, readFile } from 'node:fs/promises'
-import { defineNuxtModule, addPlugin, createResolver, addImportsDir, addServerHandler } from '@nuxt/kit'
+import { defineNuxtModule, addPlugin, createResolver, addImportsDir, addServerHandler, addServerPlugin } from '@nuxt/kit'
 import { join } from 'pathe'
 import { defu } from 'defu'
 import { randomUUID } from 'uncrypto'
@@ -45,6 +45,7 @@ export default defineNuxtModule<ModuleOptions>({
         ],
       })
     }
+    addServerPlugin(resolver.resolve('./runtime/server/plugins/oauth'))
     // Waiting for https://github.com/nuxt/nuxt/pull/24000/files
     // addServerImportsDir(resolver.resolve('./runtime/server/utils'))
     addServerHandler({

--- a/src/runtime/server/lib/oauth/facebook.ts
+++ b/src/runtime/server/lib/oauth/facebook.ts
@@ -133,7 +133,7 @@ export function facebookEventHandler({
     config.fields = config.fields || ['id', 'name']
     const fields = config.fields.join(',')
 
-    const user: any = await ofetch(
+    const user = await ofetch(
       `https://graph.facebook.com/v19.0/me?fields=${fields}&access_token=${accessToken}`,
     )
 

--- a/src/runtime/server/lib/oauth/facebook.ts
+++ b/src/runtime/server/lib/oauth/facebook.ts
@@ -32,6 +32,14 @@ export interface OAuthFacebookConfig {
   scope?: string[]
 
   /**
+   * Facebook OAuth User Fields
+   * @default [ 'id', 'name'],
+   * @see https://developers.facebook.com/docs/graph-api/guides/field-expansion
+   * @example [ 'id', 'name', 'email' ],
+   */
+  fields?: string[]
+
+  /**
    * Facebook OAuth Authorization URL
    * @default 'https://www.facebook.com/v19.0/dialog/oauth'
    */
@@ -121,9 +129,12 @@ export function facebookEventHandler({
 
     const accessToken = tokens.access_token
     // TODO: improve typing
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+
+    config.fields = config.fields || ['id', 'name']
+    const fields = config.fields.join(',')
+
     const user: any = await ofetch(
-      `https://graph.facebook.com/v19.0/me?fields=id,name&access_token=${accessToken}`,
+      `https://graph.facebook.com/v19.0/me?fields=${fields}&access_token=${accessToken}`,
     )
 
     if (!user) {

--- a/src/runtime/server/plugins/oauth.ts
+++ b/src/runtime/server/plugins/oauth.ts
@@ -1,6 +1,7 @@
-import { defineNitroPlugin } from '#imports'
+import type { NitroApp } from 'nitropack'
+import { defineNitroPlugin } from 'nitropack/runtime'
 
-export default defineNitroPlugin((nitroApp) => {
+export default defineNitroPlugin((nitroApp: NitroApp) => {
   if (process.env.NUXT_OAUTH_FACEBOOK_CLIENT_ID && process.env.NUXT_OAUTH_FACEBOOK_CLIENT_SECRET) {
   // In facebook login, the url is redirected to /#_=_ which is not a valid route
   // so we remove it from the url, we are loading this long before the app is loaded

--- a/src/runtime/server/plugins/oauth.ts
+++ b/src/runtime/server/plugins/oauth.ts
@@ -1,0 +1,22 @@
+import { defineNitroPlugin } from '#imports'
+
+export default defineNitroPlugin((nitroApp) => {
+  if (process.env.NUXT_OAUTH_FACEBOOK_CLIENT_ID && process.env.NUXT_OAUTH_FACEBOOK_CLIENT_SECRET) {
+  // In facebook login, the url is redirected to /#_=_ which is not a valid route
+  // so we remove it from the url, we are loading this long before the app is loaded
+  // by using render:html hook
+  // this is a hack, but it works
+  // https://stackoverflow.com/questions/7131909/facebook-callback-appends-to-return-url
+    nitroApp.hooks.hook('render:html', (html) => {
+      html.head.unshift(`
+      <script>
+        if (window.location.hash === "#_=_"){
+          history.replaceState
+              ? history.replaceState(null, null, window.location.href.split("#")[0])
+              : window.location.hash = "";
+        }
+      </script>
+    `)
+    })
+  }
+})


### PR DESCRIPTION
* Facebook provider was only fetching 'id' and 'name' fields, I have added config.fields support.
* Facebook login redirects with /#_=_ , to avoid ugly and wrong url hash, I have added how to remove it efficiently with nuxt3 server hooks to playground, (https://stackoverflow.com/questions/7131909/facebook-callback-appends-to-return-url)