### PR TITLE
MS OAuth - making "/me" API call configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "ofetch": "^1.3.4",
     "ohash": "^1.1.3",
     "pathe": "^1.1.2",
-    "uncrypto": "^0.1.3"
+    "uncrypto": "^0.1.3",
+    "jwt-decode": "^3.1.2"
   },
   "devDependencies": {
     "@iconify-json/simple-icons": "^1.1.99",


### PR DESCRIPTION
### Reason for change
When working with Microsoft oauth, you can either pass in MSGraph scopes like: "User.Read" or you can pass in scopes that are needed for your own resources like: "api://resources/Api.Write". However, you cannot pass in both scopes as requesting a singular token for multiple audiences is not possible (noted [here](https://stackoverflow.com/questions/72287487/azure-ad-scopes-with-different-audiences) and many other places). If you only pass in the scope for your custom resource, you then you get a 401 trying to call the "/me" endpoint (because the user.read scope is missing).

### Changes
1. "useUser" flag added to config
2. "useUser" default to false (I figured a limited user object is better than error)
3. if/else block that either fetches from "/me" or decodes the JWT using jwt-decode

### Other considerations
1. I used 3.1.2 of jwt-decode because I was getting some errors with the 4.0 version that I couldn't figure out
2. It's not possible to type the jwtDecode object as it could be two different JWT formats. I didn't what to hardcode this to the "1.0" version as to be considerate of future changes to this library and the access token used.
3. I used "displayName" and "mail" as the keys in the user object to match what those keys are in the "/me" response for consistency and to not break any downstream parsing in users app code.

### Testing
Within my personal project, I used the module locally and tested with both true/false flags on the useUser configuration key. Everything functioned as I expected it to.

