### PR TITLE
fix: add missing lang=ts for correct slot props types

### DIFF
--- a/playground/app.vue
+++ b/playground/app.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-const { loggedIn, user, session, clear, fetch } = useUserSession()
+const { user, session, fetch } = useUserSession()
 const loginModal = ref(false)
 const logging = ref(false)
 const password = ref('')
@@ -139,32 +139,36 @@ const providers = computed(() => [
     </template>
     <template #right>
       <AuthState>
-        <UButton
-          v-if="!loggedIn"
-          size="xs"
-          color="gray"
-          @click="loginModal = true"
+        <template
+          #default="{ loggedIn, clear }"
         >
-          Login
-        </UButton>
-        <UDropdown :items="[providers]">
           <UButton
-            icon="i-heroicons-chevron-down"
-            trailing
+            v-if="!loggedIn"
+            size="xs"
+            color="gray"
+            @click="loginModal = true"
+          >
+            Login
+          </UButton>
+          <UDropdown :items="[providers]">
+            <UButton
+              icon="i-heroicons-chevron-down"
+              trailing
+              color="gray"
+              size="xs"
+            >
+              Login with
+            </UButton>
+          </UDropdown>
+          <UButton
+            v-if="loggedIn"
             color="gray"
             size="xs"
+            @click="clear"
           >
-            Login with
+            Logout
           </UButton>
-        </UDropdown>
-        <UButton
-          v-if="loggedIn"
-          color="gray"
-          size="xs"
-          @click="clear"
-        >
-          Logout
-        </UButton>
+        </template>
         <template #placeholder>
           <UButton
             size="xs"

--- a/src/runtime/app/components/AuthState.vue
+++ b/src/runtime/app/components/AuthState.vue
@@ -1,4 +1,4 @@
-<script setup>
+<script lang="ts" setup>
 import { useUserSession } from '#imports'
 
 const userSession = useUserSession()

--- a/src/runtime/app/components/AuthState.vue
+++ b/src/runtime/app/components/AuthState.vue
@@ -1,14 +1,13 @@
 <script lang="ts" setup>
 import { useUserSession } from '#imports'
 
-const userSession = useUserSession()
-const { ready } = userSession
+const { loggedIn, user, clear, ready } = useUserSession()
 </script>
 
 <template>
   <slot
     v-if="ready"
-    v-bind="userSession"
+    v-bind="{ loggedIn, user, clear }"
   />
   <slot
     v-else


### PR DESCRIPTION
**Problem**
No type suggestions when use slot props

**Solution**
Add lang="ts" for component script tag

**Test**
Clone demo from readme
https://github.com/atinux/nuxt-todos-edge

- Add in app.vue AuthState component with use slot props

```
...
    <AuthState v-slot="userSession">
      {{ userSession}}
    </AuthState>

    <NuxtPage />
...
```

- pnpm i
- pnpm dev
- check userSession type (in AuthState component)  -> any
![obraz](https://github.com/Atinux/nuxt-auth-utils/assets/29805551/1885f0d8-9fef-4219-aee3-8fcc96df36db)


- go manually into AuthState component and add lang="ts" in <script
- remove .nuxt, run pnpm dev and reload ts server/ window (ctrl+shift+p >Developer:reload window)
- Check userSesstion type
![obraz](https://github.com/Atinux/nuxt-auth-utils/assets/29805551/4a4f6982-83ca-406d-a401-e5614e2d4376)


I also think that the documentation is not entirely correct because you need to use loggedIn.value instead of loggedIn.
![obraz](https://github.com/Atinux/nuxt-auth-utils/assets/29805551/542e1884-5c0a-4bf4-b7b7-dc8fd9f9225f)

