### PR TITLE
style: add lint script

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -24,6 +24,6 @@ jobs:
         run: pnpm install
 
       - name: Lint (code)
-        run: pnpm lint --fix
+        run: pnpm lint:fix
 
       - uses: autofix-ci/action@d3e591514b99d0fca6779455ff8338516663f7cc

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
   "eslint.experimental.useFlatConfig": true,
+  "prettier.enable": false
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxi prepare playground",
     "release": "npm run lint && npm run test && npm run prepack && changelogen --release && npm publish && git push --follow-tags",
     "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
     "test": "vitest run",
     "test:types": "vue-tsc --noEmit",
     "test:types:playground": "cd playground && vue-tsc --noEmit",


### PR DESCRIPTION
Hello,

Since the ESLint config use `stylistic`, it make sens to add a script to lint the repo. In the meantime, I add a setting to disable the prettier extension to avoid conflict.
