### PR TITLE
feat: add support nitro prefix env

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -50,9 +50,11 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Runtime Config
     const runtimeConfig = nuxt.options.runtimeConfig
+    const envSessionPassword = `${runtimeConfig.nitro?.envPrefix || 'NUXT_'}SESSION_PASSWORD`
+
     runtimeConfig.session = defu(runtimeConfig.session, {
       name: 'nuxt-session',
-      password: process.env.NUXT_SESSION_PASSWORD || '',
+      password: process.env[envSessionPassword] || '',
       cookie: {
         sameSite: 'lax',
       },
@@ -64,10 +66,10 @@ export default defineNuxtModule<ModuleOptions>({
       // Add it to .env
       const envPath = join(nuxt.options.rootDir, '.env')
       const envContent = await readFile(envPath, 'utf-8').catch(() => '')
-      if (!envContent.includes('NUXT_SESSION_PASSWORD')) {
+      if (!envContent.includes(envSessionPassword)) {
         await writeFile(
           envPath,
-          `${envContent ? envContent + '\n' : envContent}NUXT_SESSION_PASSWORD=${runtimeConfig.session.password}`,
+          `${envContent ? envContent + '\n' : envContent}${envSessionPassword}=${runtimeConfig.session.password}`,
           'utf-8',
         )
       }

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -95,8 +95,11 @@ let sessionConfig: SessionConfig
 
 function _useSession(event: H3Event) {
   if (!sessionConfig) {
+    const runtimeConfig = useRuntimeConfig(event)
+    const envSessionPassword = `${runtimeConfig.nitro?.envPrefix || 'NUXT_'}SESSION_PASSWORD`
+
     // @ts-expect-error hard to define with defu
-    sessionConfig = defu({ password: process.env.NUXT_SESSION_PASSWORD }, useRuntimeConfig(event).session)
+    sessionConfig = defu({ password: process.env[envSessionPassword] }, runtimeConfig.session)
   }
   return useSession<UserSession>(event, sessionConfig)
 }


### PR DESCRIPTION
### 📚 Description

Added support for custom prefix. Necessary function when the application is not using `NUXT_`, but its own e.g. `APP_`.

### 🔗 Linked issue

Resolves #132