### PR TITLE
feat: support `NUXT_OAUTH_MICROSOFT_REDIRECT_URL`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -111,6 +111,7 @@ export default defineNuxtModule<ModuleOptions>({
       authorizationURL: '',
       tokenURL: '',
       userURL: '',
+      redirectUrl: '',
     })
     // Discord OAuth
     runtimeConfig.oauth.discord = defu(runtimeConfig.oauth.discord, {


### PR DESCRIPTION
This PR seeds `runtimeConfig.oauth.microsoft.redirectUrl` so that a `NUXT_OAUTH_MICROSOFT_REDIRECT_URL` var will be applied without further configuration in nuxt.config.