### PR TITLE
feat: cognito oauth support custom domain

### DIFF
--- a/src/runtime/server/lib/oauth/cognito.ts
+++ b/src/runtime/server/lib/oauth/cognito.ts
@@ -41,6 +41,11 @@ export interface OAuthCognitoConfig {
    * @default process.env.NUXT_OAUTH_COGNITO_REDIRECT_URL or current URL
    */
   redirectURL?: string
+  /**
+   * AWS Cognito App Custom Domain – some pool configurations require this
+   * @default ''
+   */
+  domain?: string
 }
 
 export function oauthCognitoEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthCognitoConfig>) {
@@ -59,8 +64,10 @@ export function oauthCognitoEventHandler({ config, onSuccess, onError }: OAuthCo
       return onError(event, error)
     }
 
-    const authorizationURL = `https://${config.userPoolId}.auth.${config.region}.amazoncognito.com/oauth2/authorize`
-    const tokenURL = `https://${config.userPoolId}.auth.${config.region}.amazoncognito.com/oauth2/token`
+    const urlBase = config?.domain || `${config.userPoolId}.auth.${config.region}.amazoncognito.com`
+
+    const authorizationURL = `https://${urlBase}/oauth2/authorize`
+    const tokenURL = `https://${urlBase}/oauth2/token`
 
     const redirectURL = config.redirectURL || getRequestURL(event).href
     if (!code) {
@@ -107,7 +114,7 @@ export function oauthCognitoEventHandler({ config, onSuccess, onError }: OAuthCo
     const accessToken = tokens.access_token
     // TODO: improve typing
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const user: any = await $fetch(`https://${config.userPoolId}.auth.${config.region}.amazoncognito.com/oauth2/userInfo`, {
+    const user: any = await $fetch(`https://${urlBase}/oauth2/userInfo`, {
       headers: {
         Authorization: `${tokenType} ${accessToken}`,
       },


### PR DESCRIPTION
Hey there,

We have a AWS Cognito Pool configured to use a custom domain for the hosted UI ([docs on that](https://docs.aws.amazon.com/cognito/latest/developerguide/cognito-user-pools-add-custom-domain.html)).

During that configuration you can choose to delete the provided Cognito domain (Step 1.5 in the docs, see their note) – `${config.userPoolId}.auth.${config.region}.amazoncognito.com`. If that occurs then the existing implementation of `oauthCognitoEventHandler` doesn't work.

This PR adds the functionality to provide the custom domain via the provider config. If `config.domain` isn't set then the default will still be made using `config.userPoolId` and `config.region`.

