### PR TITLE
fix: paypal tokens request requires encoded  `redirect_uri`

### DIFF
--- a/src/runtime/server/lib/oauth/paypal.ts
+++ b/src/runtime/server/lib/oauth/paypal.ts
@@ -117,7 +117,7 @@ export function oauthPaypalEventHandler({ config, onSuccess, onError }: OAuthCon
       },
       params: {
         grant_type: 'authorization_code',
-        redirect_uri: encodeURIComponent(redirectURL),
+        redirect_uri: encodeURIComponent(redirectURL), // <- PayPal requires to be URL encoded
         code: query.code,
       },
     })

--- a/src/runtime/server/lib/oauth/paypal.ts
+++ b/src/runtime/server/lib/oauth/paypal.ts
@@ -117,7 +117,7 @@ export function oauthPaypalEventHandler({ config, onSuccess, onError }: OAuthCon
       },
       params: {
         grant_type: 'authorization_code',
-        redirect_uri: redirectURL,
+        redirect_uri: encodeURIComponent(redirectURL),
         code: query.code,
       },
     })


### PR DESCRIPTION
Hello! This PR re-adds the `encodeURIComponent` to the `redirect_uri` when fetching tokens.

I noticed the utils refactor in #147 broke PayPal login because the `redirect_uri` encode was removed, I should have left a comment in the code when I made the PayPal provider PR (#108) saying that at the moment PayPal login for some reason requires encoding the `redirect_uri` when fetching the tokens.

For testing:
1. Login in sandbox mode https://developer.paypal.com/dashboard/applications/sandbox
2. Go to `REST API apps` Click on `Default Application`
3. Copy `Client ID` and `Secret key 1`
4. Create a `.env` file and add the credentials respectively `NUXT_OAUTH_PAYPAL_CLIENT_ID` and `NUXT_OAUTH_PAYPAL_CLIENT_SECRET`
5. Scroll down to the `Features` section, and enable `Log in with PayPal`
6. Click on the `Advanced Settings` link below the `Log in with PayPal` checkbox
7. Set `Return URL` to `http://127.0.0.1:3000/auth/paypal`
8. Scroll down, select the scopes `Full Name` and `Email`
9. Scroll down and enable `Enable customers who have not yet confirmed their email with PayPal to log in to your app.`
10. Click on the Save button
11. Go to https://developer.paypal.com/dashboard/accounts
12. Create a new Personal or Business account (Create a new one, I don't recommend using the default ones)
13. Click on the account name to see the credentials
14. Test PayPal Login with the credentials

![image](https://github.com/user-attachments/assets/42a79b96-7bb1-49dd-8843-579525571901)
