### PR TITLE
docs: Add note to readme about session API route

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ interface UserSessionComposable {
 
 > [!IMPORTANT]
 > Nuxt Auth Utils uses the `/api/_auth/session` route for session management. Ensure your API route middleware doesn't interfere with this path.
+
 ## Server Utils
 
 The following helpers are auto-imported in your `server/` directory.

--- a/README.md
+++ b/README.md
@@ -105,10 +105,8 @@ interface UserSessionComposable {
 }
 ```
 
-**API Routes:**
-
-Nuxt Auth Utils utilizes the route `/api/_auth/session` to manage sessions. Please ensure that any middleware applied to API routes does not interfere with this route.
-
+> [!IMPORTANT]
+> Nuxt Auth Utils uses the `/api/_auth/session` route for session management. Ensure your API route middleware doesn't interfere with this path.
 ## Server Utils
 
 The following helpers are auto-imported in your `server/` directory.

--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ interface UserSessionComposable {
 }
 ```
 
+**API Routes:**
+
+Nuxt Auth Utils utilizes the route `/api/_auth/session` to manage sessions. Please ensure that any middleware applied to API routes does not interfere with this route.
+
 ## Server Utils
 
 The following helpers are auto-imported in your `server/` directory.


### PR DESCRIPTION
Closes https://github.com/atinux/nuxt-auth-utils/issues/165.

Adds a note to the README describing the `api/_auth/session` API route used by Nuxt Auth Utils, and cautioning that middleware should not be applied to this route. 

Justification: it would have saved me some time to know about this route when I was debugging why my implementation of Nuxt Auth Utils was not working properly. (And it seems that others besides me may have had this issue, cf https://github.com/atinux/nuxt-auth-utils/issues/111)