### PR TITLE
feat: add support for private data & config argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,18 @@ The following helpers are auto-imported in your `server/` directory.
 ```ts
 // Set a user session, note that this data is encrypted in the cookie but can be decrypted with an API call
 // Only store the data that allow you to recognize a user, but do not store sensitive data
-// Merges new data with existing data using defu()
+// Merges new data with existing data using unjs/defu library
 await setUserSession(event, {
+  // User data
   user: {
-    // ... user data
+    login: 'atinux'
   },
+  // Private data accessible on server/ routes
+  secure: {
+    apiToken: '1234567890'
+  },
+  // Any extra fields for the session data
   loggedInAt: new Date()
-  // Any extra fields
 })
 
 // Replace a user session. Same behaviour as setUserSession, except it does not merge data with existing data
@@ -357,6 +362,14 @@ Our defaults are:
     sameSite: 'lax'
   }
 }
+```
+
+You can also overwrite the session config by passing it as 3rd argument of the `setUserSession` and `replaceUserSession` functions:
+
+```ts
+await setUserSession(event, { ... } , {
+  maxAge: 60 * 60 * 24 * 7 // 1 week
+})
 ```
 
 Checkout the [`SessionConfig`](https://github.com/unjs/h3/blob/c04c458810e34eb15c1647e1369e7d7ef19f567d/src/utils/session.ts#L20) for all options.

--- a/playground/auth.d.ts
+++ b/playground/auth.d.ts
@@ -28,6 +28,7 @@ declare module '#auth-utils' {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     extended?: any
     loggedInAt: number
+    secure?: Record<string, unknown>
   }
 }
 

--- a/playground/server/api/session.put.ts
+++ b/playground/server/api/session.put.ts
@@ -1,0 +1,5 @@
+export default eventHandler(async (event) => {
+  const { session, config } = await readBody(event)
+
+  return setUserSession(event, session || {}, config)
+})

--- a/src/runtime/server/api/session.get.ts
+++ b/src/runtime/server/api/session.get.ts
@@ -9,5 +9,7 @@ export default eventHandler(async (event) => {
     await sessionHooks.callHookParallel('fetch', session as UserSessionRequired, event)
   }
 
-  return session
+  const { secure, ...data } = session
+
+  return data
 })

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -34,8 +34,8 @@ export async function getUserSession(event: H3Event) {
  * @param data User session data, please only store public information since it can be decoded with API calls
  * @see https://github.com/atinux/nuxt-auth-utils
  */
-export async function setUserSession(event: H3Event, data: UserSession) {
-  const session = await _useSession(event)
+export async function setUserSession(event: H3Event, data: UserSession, config?: Partial<SessionConfig>) {
+  const session = await _useSession(event, config)
 
   await session.update(defu(data, session.data))
 
@@ -47,8 +47,8 @@ export async function setUserSession(event: H3Event, data: UserSession) {
  * @param event The Request (h3) event
  * @param data User session data, please only store public information since it can be decoded with API calls
  */
-export async function replaceUserSession(event: H3Event, data: UserSession) {
-  const session = await _useSession(event)
+export async function replaceUserSession(event: H3Event, data: UserSession, config?: Partial<SessionConfig>) {
+  const session = await _useSession(event, config)
 
   await session.clear()
   await session.update(data)
@@ -93,7 +93,7 @@ export async function requireUserSession(event: H3Event, opts: { statusCode?: nu
 
 let sessionConfig: SessionConfig
 
-function _useSession(event: H3Event) {
+function _useSession(event: H3Event, config: Partial<SessionConfig> = {}) {
   if (!sessionConfig) {
     const runtimeConfig = useRuntimeConfig(event)
     const envSessionPassword = `${runtimeConfig.nitro?.envPrefix || 'NUXT_'}SESSION_PASSWORD`
@@ -101,5 +101,6 @@ function _useSession(event: H3Event) {
     // @ts-expect-error hard to define with defu
     sessionConfig = defu({ password: process.env[envSessionPassword] }, runtimeConfig.session)
   }
-  return useSession<UserSession>(event, sessionConfig)
+  const finalConfig = defu(config, sessionConfig) as SessionConfig
+  return useSession<UserSession>(event, finalConfig)
 }

--- a/src/runtime/types/session.ts
+++ b/src/runtime/types/session.ts
@@ -4,7 +4,18 @@ export interface User {
 }
 
 export interface UserSession {
+  /**
+   * User session data, available on client and server
+   */
   user?: User
+  /**
+   * Private session data, only available on server/ code
+   */
+  secure?: Record<string, unknown>
+  /**
+   * Extra session data, available on client and server
+   */
+  [key: string]: unknown
 }
 
 export interface UserSessionRequired extends UserSession {


### PR DESCRIPTION
Resolves #169 

Adding a 3rd argument to `setUserSession` and `replaceUserSession` to overwrite the [`SessionConfig`](https://github.com/unjs/h3/blob/c04c458810e34eb15c1647e1369e7d7ef19f567d/src/utils/session.ts#L20)

```ts
await setUserSession(event, { ... } , {
  maxAge: 60 * 60 * 24 * 7 // 1 week
})
```

Resolves #47 

It is now possible to set private data using the `secure` property in the session data:

```ts
await setUserSession(event, {
  // User data
  user: {
    login: 'atinux'
  },
  // Private data accessible on server/ routes
  secure: {
    apiToken: '1234567890'
  },
  // Any extra fields for the session data
  loggedInAt: new Date()
})
```