### PR TITLE
fix: UserSession secure type augmentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,10 @@ declare module '#auth-utils' {
   interface UserSession {
     // Add your own fields
   }
+
+  interface SecureSessionData {
+    // Add your own fields
+  }
 }
 
 export {}

--- a/src/runtime/types/index.ts
+++ b/src/runtime/types/index.ts
@@ -1,2 +1,2 @@
-export type { User, UserSession, UserSessionRequired, UserSessionComposable } from './session'
+export type { User, UserSession, UserSessionRequired, UserSessionComposable, SecureSessionData } from './session'
 export type { OAuthConfig, OAuthProvider, OnError } from './oauth-config'

--- a/src/runtime/types/session.ts
+++ b/src/runtime/types/session.ts
@@ -3,6 +3,9 @@ import type { ComputedRef, Ref } from 'vue'
 export interface User {
 }
 
+export interface SecureSessionData {
+}
+
 export interface UserSession {
   /**
    * User session data, available on client and server
@@ -11,7 +14,7 @@ export interface UserSession {
   /**
    * Private session data, only available on server/ code
    */
-  secure?: Record<string, unknown>
+  secure?: SecureSessionData
   /**
    * Extra session data, available on client and server
    */


### PR DESCRIPTION
Seems like `secure` type (https://github.com/atinux/nuxt-auth-utils/blob/main/src/runtime/types/session.ts#L14) can't be augmented just like in #54. This PR extracts the `secure` property type to a separated interface `SecureSessionData` that allows augmentation/overriding the default typings.

This would allow to add better typing to the `secure` property:

```ts
// auth.d.ts
declare module '#auth-utils' {
  interface SecureSessionData {
    token: string
  }
}

export {}


```