### PR TITLE
feat!: call `fetch` hook whatever is `session.user` is defined or not

### DIFF
--- a/src/runtime/server/api/session.get.ts
+++ b/src/runtime/server/api/session.get.ts
@@ -5,7 +5,8 @@ import type { UserSessionRequired } from '#auth-utils'
 export default eventHandler(async (event) => {
   const session = await getUserSession(event)
 
-  if (session.user) {
+  // If session is not empty, call fetch hook
+  if (Object.keys(session).length > 0) {
     await sessionHooks.callHookParallel('fetch', session as UserSessionRequired, event)
   }
 


### PR DESCRIPTION
resolves #175 

This is a breaking change is you are using the `fetch` hook as it is now called anytime a session is set, whatever is the `user` is set or not, see #175 for use cases.
