### PR TITLE
feat!: rename `oauth<Provider>EventHandler` to`defineOAuth<Provider>EventHandler`

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ export {}
 
 All handlers can be auto-imported and used in your server routes or API routes.
 
-The pattern is `oauth<Provider>EventHandler({ onSuccess, config?, onError? })`, example: `oauthGitHubEventHandler`.
+The pattern is `defineOAuth<Provider>EventHandler({ onSuccess, config?, onError? })`, example: `defineOAuthGitHubEventHandler`.
 
 The helper returns an event handler that automatically redirects to the provider authorization page and then calls `onSuccess` or `onError` depending on the result.
 
@@ -231,7 +231,7 @@ You can add your favorite provider by creating a new file in [src/runtime/server
 Example: `~/server/routes/auth/github.get.ts`
 
 ```ts
-export default oauthGitHubEventHandler({
+export default defineOAuthGitHubEventHandler({
   config: {
     emailRequired: true
   },

--- a/playground/server/routes/auth/auth0.get.ts
+++ b/playground/server/routes/auth/auth0.get.ts
@@ -1,4 +1,4 @@
-export default oauthAuth0EventHandler({
+export default defineOAuthAuth0EventHandler({
   config: {
     emailRequired: true,
   },

--- a/playground/server/routes/auth/battledotnet.get.ts
+++ b/playground/server/routes/auth/battledotnet.get.ts
@@ -1,4 +1,4 @@
-export default oauthBattledotnetEventHandler({
+export default defineOAuthBattledotnetEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {

--- a/playground/server/routes/auth/cognito.get.ts
+++ b/playground/server/routes/auth/cognito.get.ts
@@ -1,4 +1,4 @@
-export default oauthCognitoEventHandler({
+export default defineOAuthCognitoEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {

--- a/playground/server/routes/auth/discord.get.ts
+++ b/playground/server/routes/auth/discord.get.ts
@@ -1,4 +1,4 @@
-export default oauthDiscordEventHandler({
+export default defineOAuthDiscordEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {

--- a/playground/server/routes/auth/dropbox.get.ts
+++ b/playground/server/routes/auth/dropbox.get.ts
@@ -1,4 +1,4 @@
-export default oauthDropboxEventHandler({
+export default defineOAuthDropboxEventHandler({
   config: {
     emailRequired: true,
   },

--- a/playground/server/routes/auth/facebook.get.ts
+++ b/playground/server/routes/auth/facebook.get.ts
@@ -1,4 +1,4 @@
-export default oauthFacebookEventHandler({
+export default defineOAuthFacebookEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {

--- a/playground/server/routes/auth/github.get.ts
+++ b/playground/server/routes/auth/github.get.ts
@@ -1,4 +1,4 @@
-export default oauthGitHubEventHandler({
+export default defineOAuthGitHubEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {

--- a/playground/server/routes/auth/gitlab.get.ts
+++ b/playground/server/routes/auth/gitlab.get.ts
@@ -1,4 +1,4 @@
-export default oauthGitLabEventHandler({
+export default defineOAuthGitLabEventHandler({
   config: {
     emailRequired: true,
   },

--- a/playground/server/routes/auth/google.get.ts
+++ b/playground/server/routes/auth/google.get.ts
@@ -1,4 +1,4 @@
-export default oauthGoogleEventHandler({
+export default defineOAuthGoogleEventHandler({
   config: {
     authorizationParams: {
       access_type: 'offline',

--- a/playground/server/routes/auth/instagram.get.ts
+++ b/playground/server/routes/auth/instagram.get.ts
@@ -1,4 +1,4 @@
-export default oauthInstagramEventHandler({
+export default defineOAuthInstagramEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {

--- a/playground/server/routes/auth/keycloak.get.ts
+++ b/playground/server/routes/auth/keycloak.get.ts
@@ -1,4 +1,4 @@
-export default oauthKeycloakEventHandler({
+export default defineOAuthKeycloakEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {

--- a/playground/server/routes/auth/linkedin.get.ts
+++ b/playground/server/routes/auth/linkedin.get.ts
@@ -1,4 +1,4 @@
-export default oauthLinkedInEventHandler({
+export default defineOAuthLinkedInEventHandler({
   config: {
     emailRequired: true,
   },

--- a/playground/server/routes/auth/microsoft.get.ts
+++ b/playground/server/routes/auth/microsoft.get.ts
@@ -1,4 +1,4 @@
-export default oauthMicrosoftEventHandler({
+export default defineOAuthMicrosoftEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {

--- a/playground/server/routes/auth/paypal.get.ts
+++ b/playground/server/routes/auth/paypal.get.ts
@@ -1,4 +1,4 @@
-export default oauthPaypalEventHandler({
+export default defineOAuthPaypalEventHandler({
   config: {
     emailRequired: true,
   },

--- a/playground/server/routes/auth/spotify.get.ts
+++ b/playground/server/routes/auth/spotify.get.ts
@@ -1,4 +1,4 @@
-export default oauthSpotifyEventHandler({
+export default defineOAuthSpotifyEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {

--- a/playground/server/routes/auth/steam.get.ts
+++ b/playground/server/routes/auth/steam.get.ts
@@ -1,4 +1,4 @@
-export default oauthSteamEventHandler({
+export default defineOAuthSteamEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {

--- a/playground/server/routes/auth/tiktok.get.ts
+++ b/playground/server/routes/auth/tiktok.get.ts
@@ -1,4 +1,4 @@
-export default oauthTikTokEventHandler({
+export default defineOAuthTikTokEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {

--- a/playground/server/routes/auth/twitch.get.ts
+++ b/playground/server/routes/auth/twitch.get.ts
@@ -1,4 +1,4 @@
-export default oauthTwitchEventHandler({
+export default defineOAuthTwitchEventHandler({
   config: {
     emailRequired: true,
   },

--- a/playground/server/routes/auth/vk.get.ts
+++ b/playground/server/routes/auth/vk.get.ts
@@ -1,4 +1,4 @@
-export default oauthVKEventHandler({
+export default defineOAuthVKEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {

--- a/playground/server/routes/auth/x.get.ts
+++ b/playground/server/routes/auth/x.get.ts
@@ -1,4 +1,4 @@
-export default oauthXEventHandler({
+export default defineOAuthXEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {

--- a/playground/server/routes/auth/xsuaa.get.ts
+++ b/playground/server/routes/auth/xsuaa.get.ts
@@ -1,4 +1,4 @@
-export default oauthXSUAAEventHandler({
+export default defineOAuthXSUAAEventHandler({
   async onSuccess(event, { user }) {
     await setUserSession(event, {
       user: {

--- a/playground/server/routes/auth/yandex.get.ts
+++ b/playground/server/routes/auth/yandex.get.ts
@@ -1,4 +1,4 @@
-export default oauthYandexEventHandler({
+export default defineOAuthYandexEventHandler({
   config: {
     emailRequired: true,
   },

--- a/src/runtime/server/lib/oauth/auth0.ts
+++ b/src/runtime/server/lib/oauth/auth0.ts
@@ -65,7 +65,7 @@ export interface OAuthAuth0Config {
   redirectURL?: string
 }
 
-export function oauthAuth0EventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthAuth0Config>) {
+export function defineOAuthAuth0EventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthAuth0Config>) {
   return eventHandler(async (event: H3Event) => {
     config = defu(config, useRuntimeConfig(event).oauth?.auth0, {
       authorizationParams: {},

--- a/src/runtime/server/lib/oauth/battledotnet.ts
+++ b/src/runtime/server/lib/oauth/battledotnet.ts
@@ -54,7 +54,7 @@ export interface OAuthBattledotnetConfig {
   redirectURL?: string
 }
 
-export function oauthBattledotnetEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthBattledotnetConfig>) {
+export function defineOAuthBattledotnetEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthBattledotnetConfig>) {
   return eventHandler(async (event: H3Event) => {
     config = defu(config, useRuntimeConfig(event).oauth?.battledotnet, {
       authorizationURL: 'https://oauth.battle.net/authorize',

--- a/src/runtime/server/lib/oauth/cognito.ts
+++ b/src/runtime/server/lib/oauth/cognito.ts
@@ -49,7 +49,7 @@ export interface OAuthCognitoConfig {
   domain?: string
 }
 
-export function oauthCognitoEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthCognitoConfig>) {
+export function defineOAuthCognitoEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthCognitoConfig>) {
   return eventHandler(async (event: H3Event) => {
     config = defu(config, useRuntimeConfig(event).oauth?.cognito, {
       authorizationParams: {},

--- a/src/runtime/server/lib/oauth/discord.ts
+++ b/src/runtime/server/lib/oauth/discord.ts
@@ -59,7 +59,7 @@ export interface OAuthDiscordConfig {
   redirectURL?: string
 }
 
-export function oauthDiscordEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthDiscordConfig>) {
+export function defineOAuthDiscordEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthDiscordConfig>) {
   return eventHandler(async (event: H3Event) => {
     config = defu(config, useRuntimeConfig(event).oauth?.discord, {
       authorizationURL: 'https://discord.com/oauth2/authorize',

--- a/src/runtime/server/lib/oauth/dropbox.ts
+++ b/src/runtime/server/lib/oauth/dropbox.ts
@@ -58,7 +58,7 @@ export interface OAuthDropboxConfig {
   redirectURL?: string
 }
 
-export function oauthDropboxEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthDropboxConfig>) {
+export function defineOAuthDropboxEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthDropboxConfig>) {
   return eventHandler(async (event: H3Event) => {
     config = defu(config, useRuntimeConfig(event).oauth?.dropbox, {
       authorizationURL: 'https://www.dropbox.com/oauth2/authorize',

--- a/src/runtime/server/lib/oauth/facebook.ts
+++ b/src/runtime/server/lib/oauth/facebook.ts
@@ -57,7 +57,7 @@ export interface OAuthFacebookConfig {
   redirectURL?: string
 }
 
-export function oauthFacebookEventHandler({
+export function defineOAuthFacebookEventHandler({
   config,
   onSuccess,
   onError,

--- a/src/runtime/server/lib/oauth/github.ts
+++ b/src/runtime/server/lib/oauth/github.ts
@@ -57,7 +57,7 @@ export interface OAuthGitHubConfig {
   redirectURL?: string
 }
 
-export function oauthGitHubEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthGitHubConfig>) {
+export function defineOAuthGitHubEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthGitHubConfig>) {
   return eventHandler(async (event: H3Event) => {
     config = defu(config, useRuntimeConfig(event).oauth?.github, {
       authorizationURL: 'https://github.com/login/oauth/authorize',

--- a/src/runtime/server/lib/oauth/gitlab.ts
+++ b/src/runtime/server/lib/oauth/gitlab.ts
@@ -61,7 +61,7 @@ export interface OAuthGitLabConfig {
   redirectURL?: string
 }
 
-export function oauthGitLabEventHandler({
+export function defineOAuthGitLabEventHandler({
   config,
   onSuccess,
   onError,

--- a/src/runtime/server/lib/oauth/google.ts
+++ b/src/runtime/server/lib/oauth/google.ts
@@ -59,7 +59,7 @@ export interface OAuthGoogleConfig {
   redirectURL?: string
 }
 
-export function oauthGoogleEventHandler({
+export function defineOAuthGoogleEventHandler({
   config,
   onSuccess,
   onError,

--- a/src/runtime/server/lib/oauth/instagram.ts
+++ b/src/runtime/server/lib/oauth/instagram.ts
@@ -57,7 +57,7 @@ export interface OAuthInstagramConfig {
   redirectURL?: string
 }
 
-export function oauthInstagramEventHandler({
+export function defineOAuthInstagramEventHandler({
   config,
   onSuccess,
   onError,

--- a/src/runtime/server/lib/oauth/keycloak.ts
+++ b/src/runtime/server/lib/oauth/keycloak.ts
@@ -46,7 +46,7 @@ export interface OAuthKeycloakConfig {
   redirectURL?: string
 }
 
-export function oauthKeycloakEventHandler({
+export function defineOAuthKeycloakEventHandler({
   config,
   onSuccess,
   onError,

--- a/src/runtime/server/lib/oauth/linkedin.ts
+++ b/src/runtime/server/lib/oauth/linkedin.ts
@@ -51,7 +51,7 @@ export interface OAuthLinkedInConfig {
   redirectURL?: string
 }
 
-export function oauthLinkedInEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthLinkedInConfig>) {
+export function defineOAuthLinkedInEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthLinkedInConfig>) {
   return eventHandler(async (event: H3Event) => {
     config = defu(config, useRuntimeConfig(event).oauth?.linkedin, {
       authorizationURL: 'https://www.linkedin.com/oauth/v2/authorization',

--- a/src/runtime/server/lib/oauth/microsoft.ts
+++ b/src/runtime/server/lib/oauth/microsoft.ts
@@ -59,7 +59,7 @@ export interface OAuthMicrosoftConfig {
   redirectURL?: string
 }
 
-export function oauthMicrosoftEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthMicrosoftConfig>) {
+export function defineOAuthMicrosoftEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthMicrosoftConfig>) {
   return eventHandler(async (event: H3Event) => {
     config = defu(config, useRuntimeConfig(event).oauth?.microsoft, {
       authorizationParams: {},

--- a/src/runtime/server/lib/oauth/paypal.ts
+++ b/src/runtime/server/lib/oauth/paypal.ts
@@ -64,7 +64,7 @@ export interface OAuthPaypalConfig {
   redirectURL?: string
 }
 
-export function oauthPaypalEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthPaypalConfig>) {
+export function defineOAuthPaypalEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthPaypalConfig>) {
   return eventHandler(async (event: H3Event) => {
     config = defu(config, useRuntimeConfig(event).oauth?.paypal, {
       sandbox: import.meta.dev,

--- a/src/runtime/server/lib/oauth/spotify.ts
+++ b/src/runtime/server/lib/oauth/spotify.ts
@@ -55,7 +55,7 @@ export interface OAuthSpotifyConfig {
   redirectURL?: string
 }
 
-export function oauthSpotifyEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthSpotifyConfig>) {
+export function defineOAuthSpotifyEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthSpotifyConfig>) {
   return eventHandler(async (event: H3Event) => {
     config = defu(config, useRuntimeConfig(event).oauth?.spotify, {
       authorizationURL: 'https://accounts.spotify.com/authorize',

--- a/src/runtime/server/lib/oauth/steam.ts
+++ b/src/runtime/server/lib/oauth/steam.ts
@@ -27,7 +27,7 @@ export interface OAuthSteamConfig {
   redirectURL?: string
 }
 
-export function oauthSteamEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthSteamConfig>) {
+export function defineOAuthSteamEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthSteamConfig>) {
   return eventHandler(async (event: H3Event) => {
     config = defu(config, useRuntimeConfig(event).oauth?.steam, {
       authorizationURL: 'https://steamcommunity.com/openid/login',

--- a/src/runtime/server/lib/oauth/tiktok.ts
+++ b/src/runtime/server/lib/oauth/tiktok.ts
@@ -57,7 +57,7 @@ export interface OAuthTikTokConfig {
   redirectURL?: string
 }
 
-export function oauthTikTokEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthTikTokConfig>) {
+export function defineOAuthTikTokEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthTikTokConfig>) {
   return eventHandler(async (event: H3Event) => {
     config = defu(config, useRuntimeConfig(event).oauth?.tiktok, {
       sandbox: import.meta.dev,

--- a/src/runtime/server/lib/oauth/twitch.ts
+++ b/src/runtime/server/lib/oauth/twitch.ts
@@ -58,7 +58,7 @@ export interface OAuthTwitchConfig {
   redirectURL?: string
 }
 
-export function oauthTwitchEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthTwitchConfig>) {
+export function defineOAuthTwitchEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthTwitchConfig>) {
   return eventHandler(async (event: H3Event) => {
     config = defu(config, useRuntimeConfig(event).oauth?.twitch, {
       authorizationURL: 'https://id.twitch.tv/oauth2/authorize',

--- a/src/runtime/server/lib/oauth/vk.ts
+++ b/src/runtime/server/lib/oauth/vk.ts
@@ -65,7 +65,7 @@ export interface OAuthVKConfig {
   redirectURL?: string
 }
 
-export function oauthVKEventHandler({
+export function defineOAuthVKEventHandler({
   config,
   onSuccess,
   onError,

--- a/src/runtime/server/lib/oauth/x.ts
+++ b/src/runtime/server/lib/oauth/x.ts
@@ -62,7 +62,7 @@ export interface OAuthXConfig {
   redirectURL?: string
 }
 
-export function oauthXEventHandler({
+export function defineOAuthXEventHandler({
   config,
   onSuccess,
   onError,

--- a/src/runtime/server/lib/oauth/xsuaa.ts
+++ b/src/runtime/server/lib/oauth/xsuaa.ts
@@ -36,7 +36,7 @@ export interface OAuthXSUAAConfig {
   redirectURL?: string
 }
 
-export function oauthXSUAAEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthXSUAAConfig>) {
+export function defineOAuthXSUAAEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthXSUAAConfig>) {
   return eventHandler(async (event: H3Event) => {
     config = defu(config, useRuntimeConfig(event).oauth?.xsuaa) as OAuthXSUAAConfig
 

--- a/src/runtime/server/lib/oauth/yandex.ts
+++ b/src/runtime/server/lib/oauth/yandex.ts
@@ -63,7 +63,7 @@ export interface OAuthYandexConfig {
   redirectURL?: string
 }
 
-export function oauthYandexEventHandler({
+export function defineOAuthYandexEventHandler({
   config,
   onSuccess,
   onError,


### PR DESCRIPTION
In order to get consistent with the upcoming h3 upcoming v2 release: https://github.com/unjs/h3/blob/main/MIGRATION.md#other-deprecations

```diff
- export default oauthGitHubEventHandler(...)
+ export default defineOAuthGithubEventHandler(...)
```