### PR TITLE
chore: add `state` params in Google oauth

### DIFF
--- a/src/runtime/server/lib/oauth/google.ts
+++ b/src/runtime/server/lib/oauth/google.ts
@@ -72,7 +72,7 @@ export function oauthGoogleEventHandler({
       authorizationParams: {},
     }) as OAuthGoogleConfig
 
-    const query = getQuery<{ code?: string }>(event)
+    const query = getQuery<{ code?: string, state?: string }>(event)
 
     if (!config.clientId) {
       return handleMissingConfiguration(event, 'google', ['clientId'], onError)
@@ -89,6 +89,7 @@ export function oauthGoogleEventHandler({
           client_id: config.clientId,
           redirect_uri: redirectURL,
           scope: config.scope.join(' '),
+          state: query.state || '',
           ...config.authorizationParams,
         }),
       )


### PR DESCRIPTION
This update add the state parameter to the Google OAuth flow to enhance security and help maintain state between the request and callback.

For more details: [Google OAuth 2.0 - Request Parameter: state](https://developers.google.com/identity/protocols/oauth2/web-server#request-parameter-state).