### PR TITLE
chore: session max age note

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,10 +589,15 @@ export default defineNuxtConfig({
   runtimeConfig: {
     session: {
       maxAge: 60 * 60 * 24 * 7 // 1 week
+      cookie: {
+        maxAge: 60 * 5 // 5 minutes
+      }
     }
   }
 })
 ```
+
+> Please note that `session.maxAge` is the lifetime of the session itself and `session.cookie.maxAge` is the lifetime of the cookie storing the session.
 
 Our defaults are:
 


### PR DESCRIPTION
I've added a note and example since it is not obvious that maxAge of the session is not the same as maxAge of the cookie