### PR TITLE
feat(webauthn): add event to validateUser to track authenticated users

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,10 +351,21 @@ The following code does not include the actual database queries, but shows the g
 import { z } from 'zod'
 export default defineWebAuthnRegisterEventHandler({
   // optional
-  validateUser: z.object({
-    // we want the userName to be a valid email
-    userName: z.string().email() 
-  }).parse,
+  async validateUser(userBody, event) {
+    // bonus: check if the user is already authenticated to link a credential to his account
+    // We first check if the user is already authenticated by getting the session
+    // And verify that the email is the same as the one in session
+    const session = await getUserSession(event)
+    if (session.user?.email && session.user.email !== body.userName) {
+      throw createError({ statusCode: 400, message: 'Email not matching curent session' })
+    }
+
+    // If he registers a new account with credentials
+    return z.object({
+      // we want the userName to be a valid email
+      userName: z.string().email() 
+    }).parse(userBody)
+  },
   async onSuccess(event, { credential, user }) {
     // The credential creation has been successful
     // We need to create a user if it does not exist

--- a/src/runtime/app/composables/webauthn.ts
+++ b/src/runtime/app/composables/webauthn.ts
@@ -8,7 +8,7 @@ import {
 import type { VerifiedAuthenticationResponse, VerifiedRegistrationResponse } from '@simplewebauthn/server'
 import type { PublicKeyCredentialCreationOptionsJSON, PublicKeyCredentialRequestOptionsJSON } from '@simplewebauthn/types'
 import { ref, onMounted } from '#imports'
-import type { WebAuthnComposable } from '#auth-utils'
+import type { WebAuthnComposable, WebAuthnUser } from '#auth-utils'
 
 interface RegistrationInitResponse {
   creationOptions: PublicKeyCredentialCreationOptionsJSON
@@ -43,7 +43,7 @@ export function useWebAuthn(options: {
     useBrowserAutofill = false,
   } = options
 
-  async function register(user: { userName: string, displayName?: string }) {
+  async function register(user: WebAuthnUser) {
     const { creationOptions, attemptId } = await $fetch<RegistrationInitResponse>(registerEndpoint, {
       method: 'POST',
       body: {

--- a/src/runtime/types/webauthn.ts
+++ b/src/runtime/types/webauthn.ts
@@ -1,6 +1,6 @@
 import type { AuthenticationResponseJSON, AuthenticatorTransportFuture, RegistrationResponseJSON } from '@simplewebauthn/types'
 import type { Ref } from 'vue'
-import type { H3Event, H3Error, ValidateFunction } from 'h3'
+import type { H3Event, H3Error, ValidateResult } from 'h3'
 import type {
   GenerateAuthenticationOptionsOpts,
   GenerateRegistrationOptionsOpts,
@@ -48,13 +48,15 @@ export type RegistrationBody<T extends WebAuthnUser> = {
   response: RegistrationResponseJSON
 }
 
+export type ValidateUserFunction<T> = (userBody: WebAuthnUser, event: H3Event) => ValidateResult<T> | Promise<ValidateResult<T>>
+
 export type WebAuthnRegisterEventHandlerOptions<T extends WebAuthnUser> = WebAuthnEventHandlerBase<{
   user: T
   credential: WebAuthnCredential
   registrationInfo: Exclude<VerifiedRegistrationResponse['registrationInfo'], undefined>
 }> & {
   getOptions?: (event: H3Event, body: RegistrationBody<T>) => Partial<GenerateRegistrationOptionsOpts> | Promise<Partial<GenerateRegistrationOptionsOpts>>
-  validateUser?: ValidateFunction<T>
+  validateUser?: ValidateUserFunction<T>
   excludeCredentials?: (event: H3Event, userName: string) => CredentialsList | Promise<CredentialsList>
 }
 


### PR DESCRIPTION
resolves #272 

By giving the `event` as 2nd argument to `validateUser(userBody, event)`, we can now check if the user is authenticated to check if the `user.userName` is part of the userSession.

Example:

```ts
export default defineWebAuthnRegisterEventHandler({
  // optional
  async validateUser(userBody, event) {
    // bonus: check if the user is already authenticated to link a credential to his account
    // We first check if the user is already authenticated by getting the session
    // And verify that the email is the same as the one in session
    const session = await getUserSession(event)
    if (session.user?.email && session.user.email !== body.userName) {
      throw createError({ statusCode: 400, message: 'Email not matching curent session' })
    }

    // If he registers a new account with credentials
    return z.object({
      // we want the userName to be a valid email
      userName: z.string().email() 
    }).parse(userBody)
  },
  // ...
})
```

On the frontend, we can give the email as part of the `userName`:

```vue
<script setup lang="ts">

const { user } = useUserSession()
const { register } = useWebAuthn()

async function registerPasskeyForUser() {
  register({ userName: user.value.email })
}
</script>
```
