### PR TITLE
feat: set `email_verified` in `user` on GitHub provider

### DIFF
--- a/src/runtime/server/lib/oauth/github.ts
+++ b/src/runtime/server/lib/oauth/github.ts
@@ -148,6 +148,7 @@ export function defineOAuthGitHubEventHandler({ config, onSuccess, onError }: OA
         return onError(event, error)
       }
       user.email = primaryEmail.email
+      user.email_verified = primaryEmail.verified
     }
 
     return onSuccess(event, {


### PR DESCRIPTION
Use-case: Was creating an email verification system, and I would like to bypass the need for reverification on new accounts if the user already has an email verified in GitHub.

To avoid duplicate requests to the GitHub emails endpoint in the `onSuccess` in my app, I think it's better if the library already provided that info, since it already has access to if `emailRequired` is set to `true`.