### PR TITLE
 fix(bluesky): use local map for session storing

### DIFF
--- a/playground/app.vue
+++ b/playground/app.vue
@@ -31,7 +31,6 @@ const providers = computed(() =>
     {
       label: user.value?.bluesky || 'Bluesky',
       click() {
-        console.log('hello')
         const handle = prompt('Enter your Bluesky handle')
         if (handle) {
           navigateTo({

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -31,6 +31,7 @@ const providers = computed(() =>
     {
       label: user.value?.bluesky || 'Bluesky',
       click() {
+        console.log('hello')
         const handle = prompt('Enter your Bluesky handle')
         if (handle) {
           navigateTo({
@@ -223,7 +224,7 @@ const providers = computed(() =>
     prefetch: false,
     external: true,
     to: inPopup.value ? '#' : p.to,
-    click: inPopup.value ? () => openInPopup(p.to) : void 0,
+    click: inPopup.value ? () => openInPopup(p.to) : p.click,
   })),
 )
 </script>

--- a/src/runtime/server/lib/atproto/bluesky.ts
+++ b/src/runtime/server/lib/atproto/bluesky.ts
@@ -122,7 +122,12 @@ export class StateStore implements NodeSavedStateStore {
   }
 
   async set(key: string, val: NodeSavedState) {
-    setCookie(this.event, this.stateKey, btoa(JSON.stringify(val)))
+    setCookie(this.event, this.stateKey, btoa(JSON.stringify(val)), {
+      path: '/',
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+    })
   }
 
   async del() {


### PR DESCRIPTION
Use local map to store session. Previously, the cookie method couldn't work because a `setCookie` sets the cookie in the response, and not in the current request.

This also fixes an issue on the playground where the click handler was discarded if not using a popup