### PR TITLE
fix(oauth, apple): return tokens in response

### DIFF
--- a/playground/server/routes/auth/apple.ts
+++ b/playground/server/routes/auth/apple.ts
@@ -9,7 +9,7 @@ export default defineOAuthAppleEventHandler({
         apple: userToSet,
       },
       secure: {
-        ...tokens
+        ...tokens,
       },
       loggedInAt: Date.now(),
     })

--- a/playground/server/routes/auth/apple.ts
+++ b/playground/server/routes/auth/apple.ts
@@ -1,12 +1,15 @@
 export default defineOAuthAppleEventHandler({
-  async onSuccess(event, { user, tokens }) {
+  async onSuccess(event, { user, tokens, payload }) {
     const userToSet = user?.name?.firstName && user?.name?.lastName
       ? `${user.name.firstName} ${user.name.lastName}`
-      : user?.name?.firstName || user?.name?.lastName || tokens.email || tokens.sub
+      : user?.name?.firstName || user?.name?.lastName || payload.email || payload.sub
 
     await setUserSession(event, {
       user: {
         apple: userToSet,
+      },
+      secure: {
+        ...tokens
       },
       loggedInAt: Date.now(),
     })

--- a/src/runtime/server/lib/oauth/apple.ts
+++ b/src/runtime/server/lib/oauth/apple.ts
@@ -162,17 +162,17 @@ export function defineOAuthAppleEventHandler({
         },
       })
 
-      const tokens = await verifyJwt<OAuthAppleTokens>(accessTokenResult.id_token, {
+      const payload = await verifyJwt<OAuthAppleTokens>(accessTokenResult.id_token, {
         publicJwkUrl: 'https://appleid.apple.com/auth/keys',
         audience: config.clientId,
         issuer: 'https://appleid.apple.com',
       })
 
-      if (!tokens) {
-        return handleAccessTokenErrorResponse(event, 'apple', tokens, onError)
+      if (!payload) {
+        return handleAccessTokenErrorResponse(event, 'apple', payload, onError)
       }
 
-      return onSuccess(event, { user, tokens })
+      return onSuccess(event, { user, payload, tokens: accessTokenResult })
     }
     catch (error) {
       return handleAccessTokenErrorResponse(event, 'apple', error, onError)


### PR DESCRIPTION
The current implementation of the Apple return is a completely different from other providers (e.g. Google, Facebook).

In the current implementation, tokens are not returned as tokens but payload, which is very problematic when you want to use tokens and the same flow as for the rest of the providers, e.g. sending access_token to an additional backend.

Google returns:
- { tokens: { access_token}

Facebook returns:
- { tokens: { access_token }

the rest of the providers in the repository are similar, and apple returns the decoded jwt as tokens :/