### PR TITLE
fix(oauth, facebook): prevent duplication of config.fields and config.scope in defu merge

### DIFF
--- a/src/runtime/server/lib/oauth/facebook.ts
+++ b/src/runtime/server/lib/oauth/facebook.ts
@@ -63,7 +63,10 @@ export function defineOAuthFacebookEventHandler({
   onError,
 }: OAuthConfig<OAuthFacebookConfig>) {
   return eventHandler(async (event: H3Event) => {
-    config = defu(config, useRuntimeConfig(event).oauth?.facebook, {
+    
+    const runtimeConfig = useRuntimeConfig(event)
+    
+    config = defu(config, runtimeConfig.oauth?.facebook, {
       authorizationURL: 'https://www.facebook.com/v19.0/dialog/oauth',
       tokenURL: 'https://graph.facebook.com/v19.0/oauth/access_token',
       authorizationParams: {},
@@ -88,7 +91,7 @@ export function defineOAuthFacebookEventHandler({
     const redirectURL = config.redirectURL || getOAuthRedirectURL(event)
 
     if (!query.code) {
-      config.scope = config.scope || []
+      config.scope = runtimeConfig.oauth?.facebook?.scope || []
       // Redirect to Facebook Oauth page
       return sendRedirect(
         event,
@@ -117,7 +120,7 @@ export function defineOAuthFacebookEventHandler({
     const accessToken = tokens.access_token
     // TODO: improve typing
 
-    config.fields = config.fields || ['id', 'name']
+    config.fields = runtimeConfig.oauth?.facebook?.fields || ['id', 'name']
     const fields = config.fields.join(',')
 
     const user = await $fetch(

--- a/src/runtime/server/lib/oauth/facebook.ts
+++ b/src/runtime/server/lib/oauth/facebook.ts
@@ -63,10 +63,7 @@ export function defineOAuthFacebookEventHandler({
   onError,
 }: OAuthConfig<OAuthFacebookConfig>) {
   return eventHandler(async (event: H3Event) => {
-    
-    const runtimeConfig = useRuntimeConfig(event)
-    
-    config = defu(config, runtimeConfig.oauth?.facebook, {
+    config = defu(config, useRuntimeConfig(event).oauth?.facebook, {
       authorizationURL: 'https://www.facebook.com/v19.0/dialog/oauth',
       tokenURL: 'https://graph.facebook.com/v19.0/oauth/access_token',
       authorizationParams: {},
@@ -91,7 +88,7 @@ export function defineOAuthFacebookEventHandler({
     const redirectURL = config.redirectURL || getOAuthRedirectURL(event)
 
     if (!query.code) {
-      config.scope = runtimeConfig.oauth?.facebook?.scope || []
+      config.scope = [...new Set(config.scope)] || []
       // Redirect to Facebook Oauth page
       return sendRedirect(
         event,
@@ -120,7 +117,7 @@ export function defineOAuthFacebookEventHandler({
     const accessToken = tokens.access_token
     // TODO: improve typing
 
-    config.fields = runtimeConfig.oauth?.facebook?.fields || ['id', 'name']
+    config.fields = [...new Set(config.fields)] || ['id', 'name']
     const fields = config.fields.join(',')
 
     const user = await $fetch(

--- a/src/runtime/server/lib/oauth/facebook.ts
+++ b/src/runtime/server/lib/oauth/facebook.ts
@@ -88,7 +88,7 @@ export function defineOAuthFacebookEventHandler({
     const redirectURL = config.redirectURL || getOAuthRedirectURL(event)
 
     if (!query.code) {
-      config.scope = [...new Set(config.scope)] || []
+      config.scope = [...new Set(config.scope)]
       // Redirect to Facebook Oauth page
       return sendRedirect(
         event,
@@ -117,7 +117,7 @@ export function defineOAuthFacebookEventHandler({
     const accessToken = tokens.access_token
     // TODO: improve typing
 
-    config.fields = [...new Set(config.fields)] || ['id', 'name']
+    config.fields = [...new Set(config.fields || ['id', 'name'])]
     const fields = config.fields.join(',')
 
     const user = await $fetch(


### PR DESCRIPTION
### Summary
This fix ensures that `config.fields` and `config.scope` does not get duplicated when merging the provided configuration with the runtime configuration using `defu`. Previously, multiple merges could lead to redundant entries in `config.fields`.

### Changes
- Updated `oauth/facebook.ts` to correctly handle merging behavior.
- Added a safeguard to prevent `config.fields` and `config.scope` duplication.

### Why?
- The previous behavior caused unnecessary field repetitions, leading to potential runtime errors when scope or fields were explicitly defined in the configuration.

### How?
- Created a new const runtimeConfig outside defu to prevent duplicate fields and scope entries during the merge process.

### Testing
- Manually tested with different configurations to ensure no duplicates are created.

### Checklist
- [x] Code follows the project’s style guide