### PR TITLE
feat: support GitHub Enterprise Server and GHE.com

### DIFF
--- a/src/runtime/server/lib/oauth/github.ts
+++ b/src/runtime/server/lib/oauth/github.ts
@@ -43,6 +43,12 @@ export interface OAuthGitHubConfig {
   tokenURL?: string
 
   /**
+   * GitHub API URL
+   * @default 'https://api.github.com'
+   */
+  apiURL?: string
+
+  /**
    * Extra authorization parameters to provide to the authorization URL
    * @see https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#1-request-a-users-github-identity
    * @example { allow_signup: 'true' }
@@ -62,6 +68,7 @@ export function defineOAuthGitHubEventHandler({ config, onSuccess, onError }: OA
     config = defu(config, useRuntimeConfig(event).oauth?.github, {
       authorizationURL: 'https://github.com/login/oauth/authorize',
       tokenURL: 'https://github.com/login/oauth/access_token',
+      apiURL: 'https://api.github.com',
       authorizationParams: {},
     }) as OAuthGitHubConfig
 
@@ -117,7 +124,7 @@ export function defineOAuthGitHubEventHandler({ config, onSuccess, onError }: OA
     const accessToken = tokens.access_token
     // TODO: improve typing
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const user: any = await $fetch('https://api.github.com/user', {
+    const user: any = await $fetch(`${config.apiURL}/user`, {
       headers: {
         'User-Agent': `Github-OAuth-${config.clientId}`,
         'Authorization': `token ${accessToken}`,
@@ -128,7 +135,7 @@ export function defineOAuthGitHubEventHandler({ config, onSuccess, onError }: OA
     if (!user.email && config.emailRequired) {
     // TODO: improve typing
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const emails: any[] = await $fetch('https://api.github.com/user/emails', {
+      const emails: any[] = await $fetch(`${config.apiURL}/user/emails`, {
         headers: {
           'User-Agent': `Github-OAuth-${config.clientId}`,
           'Authorization': `token ${accessToken}`,


### PR DESCRIPTION
Replace `https://api.github.com` by a config variable so that GitHub Enterprise Server and GHE.com can be supported. Those are not only different DNS entries but also different formats: `https://<server>/api/v3`, `https://api.<tenant>.ghe.com`