### PR TITLE
feat: add support for authorization parameters and ensure state param is included from query when present in Facebook & Microsoft OAuth

### DIFF
--- a/src/runtime/server/lib/oauth/facebook.ts
+++ b/src/runtime/server/lib/oauth/facebook.ts
@@ -55,6 +55,12 @@ export interface OAuthFacebookConfig {
    * @default process.env.NUXT_OAUTH_FACEBOOK_REDIRECT_URL or current URL
    */
   redirectURL?: string
+  /**
+     * State parameter to pass custom data through the OAuth flow
+     * @default undefined
+     * @see https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1
+     */
+  state?: string
 }
 
 export function defineOAuthFacebookEventHandler({
@@ -95,6 +101,7 @@ export function defineOAuthFacebookEventHandler({
         withQuery(config.authorizationURL as string, {
           client_id: config.clientId,
           redirect_uri: redirectURL,
+          state: encodeURIComponent(JSON.stringify(config.state)),
           scope: config.scope.join(' '),
         }),
       )

--- a/src/runtime/server/lib/oauth/facebook.ts
+++ b/src/runtime/server/lib/oauth/facebook.ts
@@ -96,7 +96,7 @@ export function defineOAuthFacebookEventHandler({
           client_id: config.clientId,
           redirect_uri: redirectURL,
           scope: config.scope.join(' '),
-          state: query.state || "",
+          state: query.state || '',
           ...config.authorizationParams,
         }),
       )

--- a/src/runtime/server/lib/oauth/facebook.ts
+++ b/src/runtime/server/lib/oauth/facebook.ts
@@ -101,7 +101,7 @@ export function defineOAuthFacebookEventHandler({
         withQuery(config.authorizationURL as string, {
           client_id: config.clientId,
           redirect_uri: redirectURL,
-          state: encodeURIComponent(JSON.stringify(config.state)),
+          ...(config.state !== undefined && { state: encodeURIComponent(JSON.stringify(config.state)) }),
           scope: config.scope.join(' '),
         }),
       )

--- a/src/runtime/server/lib/oauth/facebook.ts
+++ b/src/runtime/server/lib/oauth/facebook.ts
@@ -96,6 +96,7 @@ export function defineOAuthFacebookEventHandler({
           client_id: config.clientId,
           redirect_uri: redirectURL,
           scope: config.scope.join(' '),
+          state: query.state || "",
           ...config.authorizationParams,
         }),
       )

--- a/src/runtime/server/lib/oauth/facebook.ts
+++ b/src/runtime/server/lib/oauth/facebook.ts
@@ -96,7 +96,7 @@ export function defineOAuthFacebookEventHandler({
           client_id: config.clientId,
           redirect_uri: redirectURL,
           scope: config.scope.join(' '),
-          ...config.authorizationParams
+          ...config.authorizationParams,
         }),
       )
     }

--- a/src/runtime/server/lib/oauth/facebook.ts
+++ b/src/runtime/server/lib/oauth/facebook.ts
@@ -56,10 +56,10 @@ export interface OAuthFacebookConfig {
    */
   redirectURL?: string
   /**
-     * State parameter to pass custom data through the OAuth flow
-     * @default undefined
-     * @see https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1
-     */
+   * State parameter to pass custom data through the OAuth flow
+   * @default undefined
+   * @see https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1
+   */
   state?: string
 }
 

--- a/src/runtime/server/lib/oauth/facebook.ts
+++ b/src/runtime/server/lib/oauth/facebook.ts
@@ -51,16 +51,10 @@ export interface OAuthFacebookConfig {
    */
   authorizationParams?: Record<string, string>
   /**
-   * Redirect URL to to allow overriding for situations like prod failing to determine public hostname
+   * Redirect URL to allow overriding for situations like prod failing to determine public hostname
    * @default process.env.NUXT_OAUTH_FACEBOOK_REDIRECT_URL or current URL
    */
   redirectURL?: string
-  /**
-   * State parameter to pass custom data through the OAuth flow
-   * @default undefined
-   * @see https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.1
-   */
-  state?: string
 }
 
 export function defineOAuthFacebookEventHandler({
@@ -101,8 +95,8 @@ export function defineOAuthFacebookEventHandler({
         withQuery(config.authorizationURL as string, {
           client_id: config.clientId,
           redirect_uri: redirectURL,
-          ...(config.state ? { state: encodeURIComponent(config.state) } : {}),
           scope: config.scope.join(' '),
+          ...config.authorizationParams
         }),
       )
     }

--- a/src/runtime/server/lib/oauth/facebook.ts
+++ b/src/runtime/server/lib/oauth/facebook.ts
@@ -101,7 +101,7 @@ export function defineOAuthFacebookEventHandler({
         withQuery(config.authorizationURL as string, {
           client_id: config.clientId,
           redirect_uri: redirectURL,
-          ...(config.state !== undefined && { state: encodeURIComponent(JSON.stringify(config.state)) }),
+          ...(config.state ? { state: encodeURIComponent(config.state) } : {}),
           scope: config.scope.join(' '),
         }),
       )

--- a/src/runtime/server/lib/oauth/microsoft.ts
+++ b/src/runtime/server/lib/oauth/microsoft.ts
@@ -88,7 +88,7 @@ export function defineOAuthMicrosoftEventHandler({ config, onSuccess, onError }:
           response_type: 'code',
           redirect_uri: redirectURL,
           scope: config.scope.join(' '),
-          state: query.state || "",
+          state: query.state || '',
           ...config.authorizationParams,
         }),
       )

--- a/src/runtime/server/lib/oauth/microsoft.ts
+++ b/src/runtime/server/lib/oauth/microsoft.ts
@@ -88,6 +88,7 @@ export function defineOAuthMicrosoftEventHandler({ config, onSuccess, onError }:
           response_type: 'code',
           redirect_uri: redirectURL,
           scope: config.scope.join(' '),
+          state: query.state || "",
           ...config.authorizationParams,
         }),
       )


### PR DESCRIPTION
- Added support for the `state` parameter in the Facebook OAuth configuration.
- Encoded the `state` parameter as a JSON string to allow custom data to be passed (e.g., redirect subdomain).