### PR TITLE
fix: prevent session password in .env from being included in production builds

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -147,7 +147,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     // Generate the session password
     if (nuxt.options.dev && !process.env[envSessionPassword]) {
-      runtimeConfig.session.password = randomUUID().replace(/-/g, '')
+      const password = process.env[envSessionPassword] = randomUUID().replace(/-/g, '')
       // Add it to .env
       const envPath = join(nuxt.options.rootDir, '.env')
       const envContent = await readFile(envPath, 'utf-8').catch(() => '')
@@ -156,7 +156,7 @@ export default defineNuxtModule<ModuleOptions>({
           envPath,
           `${
             envContent ? envContent + '\n' : envContent
-          }${envSessionPassword}=${runtimeConfig.session.password}`,
+          }${envSessionPassword}=${password}`,
           'utf-8',
         )
       }

--- a/src/module.ts
+++ b/src/module.ts
@@ -135,7 +135,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     runtimeConfig.session = defu(runtimeConfig.session, {
       name: 'nuxt-session',
-      password: process.env[envSessionPassword] || '',
+      password: '',
       cookie: {
         sameSite: 'lax',
       },
@@ -146,7 +146,7 @@ export default defineNuxtModule<ModuleOptions>({
     })
 
     // Generate the session password
-    if (nuxt.options.dev && !runtimeConfig.session.password) {
+    if (nuxt.options.dev && !process.env[envSessionPassword]) {
       runtimeConfig.session.password = randomUUID().replace(/-/g, '')
       // Add it to .env
       const envPath = join(nuxt.options.rootDir, '.env')

--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -112,6 +112,9 @@ function _useSession(event: UseSessionEvent, config: Partial<SessionConfig> = {}
     const envSessionPassword = `${runtimeConfig.nitro?.envPrefix || 'NUXT_'}SESSION_PASSWORD`
 
     sessionConfig = defu({ password: process.env[envSessionPassword] }, runtimeConfig.session)
+    if (!sessionConfig.password) {
+      console.error(`[nuxt-auth-utils] ${envSessionPassword} environment variable or runtimeConfig.session.password was not set.`)
+    }
   }
   const finalConfig = defu(config, sessionConfig) as SessionConfig
   return useSession<UserSession>(event, finalConfig)


### PR DESCRIPTION
This change updates handling of session password generation. It no longer manually sets the environment variable to the `runtimeConfig`, which acted as a default and included in the production build. Instead, it checks during dev that the environment variable is present or not. Loading the runtime config from environment should be handled by `nuxt` in future runs.