### PR TITLE
Add GitHub `state` param

### DIFF
--- a/src/runtime/server/lib/oauth/github.ts
+++ b/src/runtime/server/lib/oauth/github.ts
@@ -114,7 +114,7 @@ export function defineOAuthGitHubEventHandler({ config, onSuccess, onError }: OA
       authorizationParams: {},
     }) as OAuthGitHubConfig
 
-    const query = getQuery<{ code?: string, error?: string }>(event)
+    const query = getQuery<{ code?: string, error?: string, state?: string }>(event)
 
     if (query.error) {
       const error = createError({
@@ -144,6 +144,7 @@ export function defineOAuthGitHubEventHandler({ config, onSuccess, onError }: OA
           client_id: config.clientId,
           redirect_uri: redirectURL,
           scope: config.scope.join(' '),
+          state: query.state || '',
           ...config.authorizationParams,
         }),
       )


### PR DESCRIPTION
Add support for the `state` param to be passed to the GitHub OAuth. This is required to prevent CSRF attacks.

`state` is accepted by GitHub and defined here: https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#1-request-a-users-github-identity

Similar to https://github.com/atinux/nuxt-auth-utils/pull/386 & https://github.com/atinux/nuxt-auth-utils/pull/192/files