### PR TITLE
docs: fix missing auth.d.ts session types in server dir Nuxt 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,9 @@ const session = await requireUserSession(event)
 
 You can define the type for your user session by creating a type declaration file (for example, `auth.d.ts`) in your project to augment the `UserSession` type:
 
+> [!NOTE]
+> If you are using Nuxt >=4.0.0 or compatibility version 4 add the `auth.d.ts` file to the `shared` directory to get the correct types in server and client.
+
 ```ts
 // auth.d.ts
 declare module '#auth-utils' {


### PR DESCRIPTION
When `auth.d.ts` file is in the root of the project, session types only resolve to the augmentation in the `app` directory. In `server/` the types resolve to the empty interfaces in the `session.d.ts` file.

This PR documents how to fix that by moving your `auth.d.ts` file to the `shared/` folder in Nuxt v4 or compatibilityVersion 4.