### PR TITLE
fix: Add configuruable scope to Authentik provider

### DIFF
--- a/src/runtime/server/lib/oauth/authentik.ts
+++ b/src/runtime/server/lib/oauth/authentik.ts
@@ -31,7 +31,7 @@ export interface OAuthAuthentikConfig {
 
   /**
    * Authentik Scope
-   * @default []
+   * @default ['openid', 'profile', 'email']
    */
   scope?: string[]
 }


### PR DESCRIPTION
Add "scope" to the authentik config with default ['openid', 'profile', 'email']

Fix https://github.com/atinux/nuxt-auth-utils/issues/421