### PR TITLE
fix: correct handling of NUXT_SESSION_PASSWORD in _useSession

### DIFF
--- a/src/runtime/server/utils/session.ts
+++ b/src/runtime/server/utils/session.ts
@@ -109,7 +109,7 @@ let sessionConfig: SessionConfig
 function _useSession(event: UseSessionEvent, config: Partial<SessionConfig> = {}) {
   if (!sessionConfig) {
     const runtimeConfig = useRuntimeConfig(isEvent(event) ? event : undefined)
-    const envSessionPassword = `${runtimeConfig.nitro?.envPrefix || 'NUXT_'}SESSION_PASSWORD`
+    const envSessionPassword = `${runtimeConfig.nitro?.envPrefix || 'NUXT_SESSION_PASSWORD'
 
     sessionConfig = defu({ password: process.env[envSessionPassword] }, runtimeConfig.session)
     if (!sessionConfig.password) {


### PR DESCRIPTION
This pull request fixes a typo in the _useSession function that prevented the correct resolution of the NUXT_SESSION_PASSWORD environment variable. Due to this typo, the session password was not being set, which could cause authentication failures.