### PR TITLE
fix(zitadel): don't prefix domain with `https://` if another protocol is used

### DIFF
--- a/src/runtime/server/lib/oauth/zitadel.ts
+++ b/src/runtime/server/lib/oauth/zitadel.ts
@@ -65,7 +65,7 @@ export function defineOAuthZitadelEventHandler({ config, onSuccess, onError }: O
       return handleMissingConfiguration(event, 'zitadel', ['clientId', 'domain'], onError)
     }
 
-    const domain = hasProtocol(config.domain) ? config.domain : `https://${config.domain}`
+    const domain = hasProtocol(config.domain as string) ? config.domain : `https://${config.domain}`
     const authorizationURL = `${domain}/oauth/v2/authorize`
     const tokenURL = `${domain}/oauth/v2/token`
     const redirectURL = config.redirectURL || getOAuthRedirectURL(event)


### PR DESCRIPTION
Currently, it's impossible to use non-https base URL in the Zitadel connector, since the connector always prefixes the domain with `https://`.

This is very inconvenient when testing the setup locally, since locally we usually don't use https.

The PR fixes the issue.