### PR TITLE
feat: use nuxt-site-config module if available for origin extraction

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -102,6 +102,7 @@ export default defineNuxtModule<ModuleOptions>({
     }
     // Server
     addServerPlugin(resolver.resolve('./runtime/server/plugins/oauth'))
+    addServerPlugin(resolver.resolve('./runtime/server/plugins/site-config'))
     addServerImportsDir(resolver.resolve('./runtime/server/lib/oauth'))
     if (nuxt.options.nitro?.experimental?.websocket) {
       addServerPlugin(resolver.resolve('./runtime/server/plugins/ws'))
@@ -140,14 +141,13 @@ export default defineNuxtModule<ModuleOptions>({
     nuxt.options.nitro.unenv.external ||= []
     // @ts-expect-error see comment above
     if (!nuxt.options.nitro.unenv.external.includes('node:crypto')) {
-    // @ts-expect-error see comment above
+      // @ts-expect-error see comment above
       nuxt.options.nitro.unenv.external.push('node:crypto')
     }
 
     // Runtime Config
     const runtimeConfig = nuxt.options.runtimeConfig
-    const envSessionPassword = `${
-      runtimeConfig.nitro?.envPrefix || 'NUXT_'
+    const envSessionPassword = `${runtimeConfig.nitro?.envPrefix || 'NUXT_'
     }SESSION_PASSWORD`
 
     runtimeConfig.session = defu(runtimeConfig.session, {
@@ -176,8 +176,7 @@ export default defineNuxtModule<ModuleOptions>({
         if (!envContent.includes(envSessionPassword)) {
           await writeFile(
             envPath,
-            `${
-              envContent ? envContent + '\n' : envContent
+            `${envContent ? envContent + '\n' : envContent
             }${envSessionPassword}=${password}`,
             'utf-8',
           )

--- a/src/runtime/server/lib/utils.ts
+++ b/src/runtime/server/lib/utils.ts
@@ -6,6 +6,7 @@ import * as jose from 'jose'
 import { subtle, getRandomValues } from 'uncrypto'
 import type { OAuthProvider, OnError } from '#auth-utils'
 import { createError } from '#imports'
+import { resolveURL } from 'ufo'
 
 // Determine if we are in development mode
 const isDevelopment = process.env.NODE_ENV === 'development'
@@ -15,8 +16,15 @@ const OAUTH_COOKIE_MAX_AGE = 60 * 10
 
 export function getOAuthRedirectURL(event: H3Event): string {
   const requestURL = getRequestURL(event)
+  let redirectURL = `${requestURL.protocol}//${requestURL.host}${requestURL.pathname}`
+  const getNitroOrigin = event.context.__authUtilsSiteConfig.getNitroOrigin
 
-  return `${requestURL.protocol}//${requestURL.host}${requestURL.pathname}`
+  if (getNitroOrigin) {
+    const siteOrigin = getNitroOrigin(event)
+    redirectURL = resolveURL(siteOrigin, requestURL.pathname)
+  }
+
+  return redirectURL
 }
 
 /**

--- a/src/runtime/server/plugins/site-config.ts
+++ b/src/runtime/server/plugins/site-config.ts
@@ -1,0 +1,19 @@
+import { defineNitroPlugin } from 'nitropack/dist/runtime/plugin'
+import type { H3Event } from 'h3'
+
+export default defineNitroPlugin(async (_nitroApp) => {
+  let getNitroOrigin: ((event: H3Event) => string) | undefined
+
+  try {
+    // @ts-expect-error the package is optional
+    const siteConfigComp = await import('#site-config/server/composables')
+    getNitroOrigin = siteConfigComp.getNitroOrigin
+  }
+  catch {
+    // We can safely ignore it because site config is not rewuired
+  }
+
+  _nitroApp.hooks.hook('request', (event) => {
+    event.context.__authUtilsSiteConfig = { getNitroOrigin }
+  })
+})


### PR DESCRIPTION
Fixes #500 

I've added an extra plugin to check if nuxt site config is available, and use it's `getNitroOrigin` composable at the `getOAuthRedirectURL` method