### PR TITLE
docs: fix passwordNeedsRehash usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ if (await verifyPassword(hashedPassword, 'user_password')) {
 It also provides a `passwordNeedsRehash` function to check if a password needs to be rehashed. This is useful when the hash settings are changed, such as as increasing the scrypt cost parameters.
 
 ```ts
-const needsRehash = await passwordNeedsRehash(hashedPassword)
+const needsRehash = passwordNeedsRehash(hashedPassword)
 
 if (needsRehash) {
   // Password needs to be rehashed


### PR DESCRIPTION
The `passwordNeedsRehash` function is synchronous, but the example showed it being used with 'await'. This commit removes the misleading keyword to align with the actual implementation.

https://github.com/atinux/nuxt-auth-utils/blob/v0.5.28/src/runtime/server/utils/password.ts#L46-L64