### PR TITLE
chore: add types for Spotify provider and remove deprecated email scope

### DIFF
--- a/src/runtime/server/lib/oauth/spotify.ts
+++ b/src/runtime/server/lib/oauth/spotify.ts
@@ -21,14 +21,9 @@ export interface OAuthSpotifyConfig {
    * Spotify OAuth Scope
    * @default []
    * @see https://developer.spotify.com/documentation/web-api/concepts/scopes
-   * @example ['user-read-email']
+   * @example ['playlist-read-private']
    */
   scope?: string[]
-  /**
-   * Require email from user, adds the ['user-read-email'] scope if not present
-   * @default false
-   */
-  emailRequired?: boolean
 
   /**
    * Spotify OAuth Authorization URL
@@ -96,9 +91,6 @@ export function defineOAuthSpotifyEventHandler({ config, onSuccess, onError }: O
 
     if (!query.code) {
       config.scope = config.scope || []
-      if (config.emailRequired && !config.scope.includes('user-read-email')) {
-        config.scope.push('user-read-email')
-      }
       // Redirect to Spotify Oauth page
       return sendRedirect(
         event,

--- a/src/runtime/server/lib/oauth/spotify.ts
+++ b/src/runtime/server/lib/oauth/spotify.ts
@@ -55,7 +55,31 @@ export interface OAuthSpotifyConfig {
   redirectURL?: string
 }
 
-export function defineOAuthSpotifyEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthSpotifyConfig>) {
+interface SpotifyUser {
+  display_name: string
+  external_urls: {
+    spotify: string
+  }
+  href: string
+  id: string
+  images: {
+    url: string
+    height: number
+    width: number
+  }[]
+  type: string
+  uri: string
+}
+
+interface SpotifyTokens {
+  access_token: string
+  token_type: string
+  scope: string
+  expires_in: number
+  refresh_token: string
+}
+
+export function defineOAuthSpotifyEventHandler({ config, onSuccess, onError }: OAuthConfig<OAuthSpotifyConfig, { user: SpotifyUser, tokens: SpotifyTokens }>) {
   return eventHandler(async (event: H3Event) => {
     config = defu(config, useRuntimeConfig(event).oauth?.spotify, {
       authorizationURL: 'https://accounts.spotify.com/authorize',
@@ -106,9 +130,7 @@ export function defineOAuthSpotifyEventHandler({ config, onSuccess, onError }: O
 
     const accessToken = tokens.access_token
 
-    // TODO: improve typing
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const user: any = await $fetch('https://api.spotify.com/v1/me', {
+    const user = await $fetch<SpotifyUser>('https://api.spotify.com/v1/me', {
       headers: {
         Authorization: `Bearer ${accessToken}`,
       },


### PR DESCRIPTION
Add user and tokens type definitions and removed deprecated `user-read-email` scope (used only for the current user endpoint) for the Spotify provider.

Note: didn't add deprecated current user types.

- Current user response: https://developer.spotify.com/documentation/web-api/reference/get-current-users-profile
- Tokens response: https://developer.spotify.com/documentation/web-api/tutorials/code-flow#response-1
- Deprecation notes for user: https://developer.spotify.com/documentation/web-api/references/changes/february-2026#user