### PR TITLE
fix: use xForwardedHost option in getRequestURL

### DIFF
--- a/src/runtime/server/lib/utils.ts
+++ b/src/runtime/server/lib/utils.ts
@@ -14,7 +14,7 @@ const isDevelopment = process.env.NODE_ENV === 'development'
 const OAUTH_COOKIE_MAX_AGE = 60 * 10
 
 export function getOAuthRedirectURL(event: H3Event): string {
-  const requestURL = getRequestURL(event)
+  const requestURL = getRequestURL(event, { xForwardedHost: true })
 
   return `${requestURL.protocol}//${requestURL.host}${requestURL.pathname}`
 }


### PR DESCRIPTION
In cloud setups mostly firewalls are used before the main application. In order for the returnurl to be correct we need to honor the X-Forwarded-Host Header.