### PR TITLE
fix(oidc): dedupe 'openid' scope in config

### DIFF
--- a/src/runtime/server/lib/oauth/oidc.ts
+++ b/src/runtime/server/lib/oauth/oidc.ts
@@ -243,9 +243,10 @@ interface OIDCConfiguration {
  */
 export function defineOAuthOidcEventHandler<TUser = OidcUser>({ config, onSuccess, onError }: OAuthConfig<OAuthOidcConfig, { user: TUser, tokens: OidcTokens }>) {
   return eventHandler(async (event: H3Event) => {
-    config = defu(config, useRuntimeConfig(event).oauth.oidc, {
-      scope: ['openid'],
-    } satisfies OAuthOidcConfig)
+    config = defu(config, useRuntimeConfig(event).oauth.oidc)
+    if (!config.scope?.includes('openid')) {
+      config.scope = [...(config.scope || []), 'openid']
+    }
 
     const query = getQuery<{ code?: string, error?: string, state?: string }>(event)
 


### PR DESCRIPTION
Fixes: #516

## Changes

Replaced the `defu` default `[{ scope: ['openid'] }]` with an explicit check that ensures 'openid' is present without duplication, consistent with how the Dropbox provider already handles it:

https://github.com/atinux/nuxt-auth-utils/blob/ceb366b629130a2da539750a86b6cccdcc70ae00/src/runtime/server/lib/oauth/dropbox.ts#L78-L80