### PR TITLE
fix(sessison): safe usage of localStorage (#519)

### DIFF
--- a/src/runtime/app/composables/session.ts
+++ b/src/runtime/app/composables/session.ts
@@ -45,8 +45,13 @@ export function useUserSession(): UserSessionComposable {
     }
   }
   const openInPopup = (route: string, size: { width?: number, height?: number } = {}) => {
-    // Set a local storage item to tell the popup that we pending auth
-    localStorage.setItem('temp-nuxt-auth-utils-popup', 'true')
+    try {
+      // Set a local storage item to tell the popup that we pending auth
+      localStorage.setItem('temp-nuxt-auth-utils-popup', 'true')
+    }
+    catch (error) {
+      console.error('[nuxt-auth-utils] Could not use localStorage during popup flow initialization.', error)
+    }
 
     const width = size.width ?? 960
     const height = size.height ?? 600

--- a/src/runtime/app/plugins/session.client.ts
+++ b/src/runtime/app/plugins/session.client.ts
@@ -15,10 +15,15 @@ export default defineNuxtPlugin(async (nuxtApp: NuxtApp) => {
     })
   }
 
-  if (localStorage.getItem('temp-nuxt-auth-utils-popup')) {
-    // There is a local storage item. That's mean we are coming back in the popup
-    localStorage.removeItem('temp-nuxt-auth-utils-popup')
-    const error = useError()
-    if (!error.value) window.close()
+  try {
+    if (localStorage.getItem('temp-nuxt-auth-utils-popup')) {
+      // There is a local storage item. That's mean we are coming back in the popup
+      localStorage.removeItem('temp-nuxt-auth-utils-popup')
+      const error = useError()
+      if (!error.value) window.close()
+    }
+  }
+  catch (error) {
+    console.error('[nuxt-auth-utils] Could not use localStorage during popup flow last step. Popup won\'t be closed automatically.', error)
   }
 })


### PR DESCRIPTION
Wrap calls to `localStorage` in try/catch, so that the app does not crash during the app mounting.

Fixes #519 