### PR TITLE
fix(oauth): route 400 token-exchange errors (invalid_grant) to onError

### DIFF
--- a/src/runtime/server/lib/utils.ts
+++ b/src/runtime/server/lib/utils.ts
@@ -60,9 +60,17 @@ export async function requestAccessToken(url: string, options: RequestAccessToke
     body,
   }).catch((error) => {
     /**
-     * For a better error handling, only unauthorized errors are intercepted, and other errors are re-thrown.
+     * Per RFC 6749 §5.2 the token endpoint returns a 4xx status (usually 400,
+     * e.g. `invalid_grant`) with a structured `{ error }` body for OAuth
+     * failures — only `invalid_client` may use 401. Intercept any such
+     * structured error response so it is routed to `onError`, and re-throw
+     * everything else (network errors, 5xx, opaque non-OAuth responses).
      */
-    if (error instanceof FetchError && error.status === 401) {
+    if (
+      error instanceof FetchError
+      && error.status && error.status >= 400 && error.status < 500
+      && error.data?.error
+    ) {
       return error.data
     }
     throw error


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #525

### ❓ Type of change

- [x] 🐛 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

`requestAccessToken` only intercepted **`401`** token-exchange failures and routed them to `onError`; every other status was re-thrown. But per **[RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2)** the token endpoint returns **`400 Bad Request`** for the common OAuth failures (`invalid_grant`, `invalid_request`, `unauthorized_client`, `unsupported_grant_type`, `invalid_scope`) — only `invalid_client` *may* use `401`.

As a result, the most common real-world failure — `400 invalid_grant` from a reused/expired one-time authorization code (back/forward navigation, callback refresh, link prefetch/scanner, `prompt=none` silent re-auth) — **bypassed `onError`** and surfaced as an `unhandled` error. Reproduced on Google, Facebook and Microsoft, which all share `requestAccessToken`.

This PR routes any **4xx** response that carries a structured OAuth `error` body to the existing `handleAccessTokenErrorResponse`/`onError` path, while still re-throwing genuine network errors, 5xx, and opaque non-OAuth responses.

```diff
-    /**
-     * For a better error handling, only unauthorized errors are intercepted, and other errors are re-thrown.
-     */
-    if (error instanceof FetchError && error.status === 401) {
-      return error.data
-    }
-    throw error
+    /**
+     * Per RFC 6749 §5.2 the token endpoint returns a 4xx status (usually 400,
+     * e.g. `invalid_grant`) with a structured `{ error }` body for OAuth
+     * failures — only `invalid_client` may use 401. Intercept any such
+     * structured error response so it is routed to `onError`, and re-throw
+     * everything else (network errors, 5xx, opaque non-OAuth responses).
+     */
+    if (
+      error instanceof FetchError
+      && error.status && error.status >= 400 && error.status < 500
+      && error.data?.error
+    ) {
+      return error.data
+    }
+    throw error
```

**Why gated on `error.data?.error`:** ensures only structured OAuth error responses (per §5.2) are swallowed — opaque 4xx HTML/proxy errors still throw. **Backward compatible:** `401 invalid_client` continues to be routed to `onError` exactly as before.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication error handling to better capture and report OAuth token endpoint failures, enabling more comprehensive error detection and reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->