### PR TITLE
fix: update missing configuration for Shopify customer

### DIFF
--- a/src/runtime/server/lib/oauth/shopifyCustomer.ts
+++ b/src/runtime/server/lib/oauth/shopifyCustomer.ts
@@ -75,7 +75,7 @@ export function defineOAuthShopifyCustomerEventHandler({
     const query = getQuery<{ code?: string, state?: string }>(event)
 
     if (!config.clientId || !config.shopDomain) {
-      return handleMissingConfiguration(event, 'spotify', ['clientId', 'shopDomain'], onError)
+      return handleMissingConfiguration(event, 'shopifyCustomer', ['clientId', 'shopDomain'], onError)
     }
 
     // Create pkce verifier


### PR DESCRIPTION
Change spotify to shopifyCustomer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected provider identifier in Shopify OAuth configuration error messages to ensure accurate troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->